### PR TITLE
feat: 생산입고 상태 변경(결재완료, 생산입고완료)

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
@@ -25,13 +25,15 @@ public enum ErrorCodeType {
 
     // 상품입고 관련 오류
     PRODUCTION_RECEIVING_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCTION_RECEIVING_ERROR_001", "생산입고를 찾을 수 없습니다."),
-    PRODUCTION_RECEIVING_UPDATE_ERROR(HttpStatus.BAD_REQUEST, "PRODUCTION_RECEIVING_ERROR_003", "이미 결재가 완료된 상품입고입니다."),
+    PRODUCTION_RECEIVING_UPDATE_ERROR(HttpStatus.BAD_REQUEST, "PRODUCTION_RECEIVING_ERROR_002", "이미 결재가 완료된 상품입고입니다."),
+    PRODUCTION_RECEIVING_UPDATE_COMPLETE_ERROR(HttpStatus.BAD_REQUEST, "PRODUCTION_RECEIVING_ERROR_003", "결재가 완료된 상품입고만 상품입고 완료 상태로 변경할 수 있습니다."),
 
     // 창고 관련 오류
     WAREHOUSE_NOT_FOUND(HttpStatus.NOT_FOUND, "WAREHOUSE_ERROR_001", "창고를 찾을 수 없습니다."),
 
     // 작업지시서 오류
     WORK_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "WORK_ORDER_ERROR_001", "작업지시서를 찾을 수 없습니다."),
+    WORK_ORDER_STATUS_ERROR(HttpStatus.BAD_REQUEST, "WORK_ORDER_ERROR_002", "작업지시가 완료된 경우만 생산 입고를 작성할 수 있습니다."),
 
     // 회원 오류
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_ERROR_001", "회원을 찾을 수 없습니다."),

--- a/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/aggregate/entity/ItemInventory.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/aggregate/entity/ItemInventory.java
@@ -1,10 +1,13 @@
 package error.pirate.backend.item.command.domain.aggregate.entity;
 
+import error.pirate.backend.warehouse.command.domain.aggregate.entity.Warehouse;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -12,20 +15,38 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemInventory {
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itemInventorySeq;
 
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     @JoinColumn(name = "itemSeq")
     private Item item; // 품목
 
-    private int itemInventoryQuantityReceived; // 품목 재고 입고 수량
+    private Integer itemInventoryQuantityReceived; // 품목 재고 입고 수량
 
-    private int itemInventoryRemainAmount; // 품목 재고 잔량
+    private Integer itemInventoryRemainAmount; // 품목 재고 잔량
 
+    @CreatedDate
     private LocalDateTime itemInventoryReceiptDate; // 품목 재고 입고일
 
     private LocalDateTime itemInventoryExpirationDate; // 품목 재고 유통기한
 
-    private String itemInventoryNote; // 품목 재고 비고
+    public static ItemInventory createItemInventory(Item item, Integer itemInventoryQuantityReceived,
+                                             Integer itemInventoryRemainAmount) {
+        ItemInventory itemInventory = new ItemInventory(item, itemInventoryQuantityReceived, itemInventoryRemainAmount);
+        itemInventory.specifyItem(item);
+
+        return itemInventory;
+    }
+
+    protected ItemInventory(Item item, Integer itemInventoryQuantityReceived, Integer itemInventoryRemainAmount) {
+        this.itemInventoryQuantityReceived = itemInventoryQuantityReceived;
+        this.itemInventoryRemainAmount = itemInventoryRemainAmount;
+        this.itemInventoryReceiptDate = LocalDateTime.now();
+        this.itemInventoryExpirationDate = LocalDateTime.now().plusDays(item.getItemExpirationHour());
+    }
+
+    private void specifyItem(Item item) {
+        this.item = item;
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/ItemInventoryRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/ItemInventoryRepository.java
@@ -1,0 +1,7 @@
+package error.pirate.backend.item.command.domain.repository;
+
+import error.pirate.backend.item.command.domain.aggregate.entity.ItemInventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemInventoryRepository extends JpaRepository<ItemInventory, Long> {
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
@@ -35,7 +35,21 @@ public class ProductionReceivingController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @PutMapping("/payment/{productionReceivingSeq}")
+    @Operation(summary = "생산입고 결재")
+    public ResponseEntity<Void> updateProductionReceivingApproval(@PathVariable Long productionReceivingSeq) {
+        productionReceivingService.updateProductionReceivingApproval(productionReceivingSeq);
 
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/complete/{productionReceivingSeq}")
+    @Operation(summary = "생산입고 완료")
+    public ResponseEntity<Void> updateProductionReceivingComplete(@PathVariable Long productionReceivingSeq) {
+        productionReceivingService.updateProductionReceivingComplete(productionReceivingSeq);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 
     @DeleteMapping("/{productionReceivingSeq}")
     @Operation(summary = "생산입고 삭제")

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
@@ -35,7 +35,7 @@ public class ProductionReceivingController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @PutMapping("/payment/{productionReceivingSeq}")
+    @PutMapping("/approval/{productionReceivingSeq}")
     @Operation(summary = "생산입고 결재")
     public ResponseEntity<Void> updateProductionReceivingApproval(@PathVariable Long productionReceivingSeq) {
         productionReceivingService.updateProductionReceivingApproval(productionReceivingSeq);

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/controller/ProductionReceivingController.java
@@ -35,6 +35,8 @@ public class ProductionReceivingController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+
+
     @DeleteMapping("/{productionReceivingSeq}")
     @Operation(summary = "생산입고 삭제")
     public ResponseEntity<Void> deleteProductionReceiving(@PathVariable Long productionReceivingSeq) {

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/dto/ProductionReceivingUpdateRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/application/dto/ProductionReceivingUpdateRequest.java
@@ -17,7 +17,6 @@ public class ProductionReceivingUpdateRequest {
     private Long storeWarehouseSeq; // 입고 창고 번호
     private String productionReceivingName; // 생산입고명
     private Integer productionReceivingExtendedPrice; // 생산입고 총액
-    private ProductionReceivingStatus productionReceivingStatus; // 생산입고 상태
     private String productionReceivingNote; // 생산입고 비고
     private List<ProductionReceivingItemDTO> productionReceivingItemList; // 생산입고 품목
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
@@ -112,4 +112,8 @@ public class ProductionReceiving {
         }
     }
 
+    // 결재 시 결재 후로 상태 변경
+    public void updateProductionReceivingApproval() {
+        this.productionReceivingStatus = ProductionReceivingStatus.AFTER;
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
@@ -116,4 +116,9 @@ public class ProductionReceiving {
     public void updateProductionReceivingApproval() {
         this.productionReceivingStatus = ProductionReceivingStatus.AFTER;
     }
+
+    // 생산입고 완료 시 생산완료로 상태 변경
+    public void updateProductionReceivingComplete() {
+        this.productionReceivingStatus = ProductionReceivingStatus.COMPLETE;
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceiving.java
@@ -107,9 +107,6 @@ public class ProductionReceiving {
         if(NullCheck.nullOrZeroCheck(request.getProductionReceivingExtendedPrice())) {
             this.productionReceivingExtendedPrice = request.getProductionReceivingExtendedPrice();
         }
-        if(NullCheck.nullCheck(request.getProductionReceivingStatus())) {
-            this.productionReceivingStatus = request.getProductionReceivingStatus();
-        }
         if(NullCheck.nullCheck(request.getProductionReceivingNote())) {
             this.productionReceivingNote = request.getProductionReceivingNote();
         }

--- a/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceivingStatus.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/productionReceiving/command/domain/aggregate/entity/ProductionReceivingStatus.java
@@ -3,5 +3,6 @@ package error.pirate.backend.productionReceiving.command.domain.aggregate.entity
 public enum ProductionReceivingStatus {
     BEFORE, // 결재전
     AFTER,  // 결재후
+    COMPLETE, // 생산입고 완료
     DELETE // 삭제
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/aggregate/entity/SalesOrder.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/aggregate/entity/SalesOrder.java
@@ -55,4 +55,8 @@ public class SalesOrder {
     private Integer salesOrderTotalQuantity; // 주문서 총 수량
 
     private String salesOrderNote; // 주문서 비고
+
+    public void updateSalesOrderStatus(SalesOrderStatus salesOrderStatus) {
+        this.salesOrderStatus = salesOrderStatus;
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/repository/SalesOrderRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/repository/SalesOrderRepository.java
@@ -1,7 +1,9 @@
 package error.pirate.backend.salesOrder.command.domain.repository;
 
 import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
+import error.pirate.backend.salesOrder.query.repository.SalesOrderQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SalesOrderRepository extends JpaRepository<SalesOrder, Long> {
+public interface SalesOrderRepository extends JpaRepository<SalesOrder, Long>, SalesOrderQueryRepository {
+
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/SalesOrderQueryRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/SalesOrderQueryRepository.java
@@ -1,0 +1,7 @@
+package error.pirate.backend.salesOrder.query.repository;
+
+import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
+
+public interface SalesOrderQueryRepository {
+    SalesOrder findByProductionReceivingSeq(Long productionReceivingSeq);
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/impl/SalesOrderQueryRepositoryImpl.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/impl/SalesOrderQueryRepositoryImpl.java
@@ -27,8 +27,8 @@ public class SalesOrderQueryRepositoryImpl implements SalesOrderQueryRepository 
     public SalesOrder findByProductionReceivingSeq(Long productionReceivingSeq) {
         return queryFactory
                 .selectFrom(salesOrder)
-                .leftJoin(salesOrder).on(workOrder.salesOrder.salesOrderSeq.eq(salesOrder.salesOrderSeq))
-                .leftJoin(workOrder).on(productionReceiving.workOrder.workOrderSeq.eq(workOrder.workOrderSeq))
+                .leftJoin(workOrder).on(workOrder.salesOrder.salesOrderSeq.eq(salesOrder.salesOrderSeq))
+                .leftJoin(productionReceiving).on(productionReceiving.workOrder.eq(workOrder))
                 .where(productionReceiving.productionReceivingSeq.eq(productionReceivingSeq))
                 .fetchOne();
     }

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/impl/SalesOrderQueryRepositoryImpl.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/query/repository/impl/SalesOrderQueryRepositoryImpl.java
@@ -1,0 +1,35 @@
+package error.pirate.backend.salesOrder.query.repository.impl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import error.pirate.backend.productionReceiving.command.domain.aggregate.entity.ProductionReceiving;
+import error.pirate.backend.productionReceiving.command.domain.aggregate.entity.ProductionReceivingStatus;
+import error.pirate.backend.productionReceiving.query.dto.ProductionReceivingListDTO;
+import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
+import error.pirate.backend.salesOrder.query.dto.SalesOrderDTO;
+import error.pirate.backend.salesOrder.query.repository.SalesOrderQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static error.pirate.backend.productionReceiving.command.domain.aggregate.entity.QProductionReceiving.productionReceiving;
+import static error.pirate.backend.salesOrder.command.domain.aggregate.entity.QSalesOrder.salesOrder;
+import static error.pirate.backend.workOrder.command.domain.aggregate.entity.QWorkOrder.workOrder;
+
+@Repository
+@RequiredArgsConstructor
+public class SalesOrderQueryRepositoryImpl implements SalesOrderQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public SalesOrder findByProductionReceivingSeq(Long productionReceivingSeq) {
+        return queryFactory
+                .selectFrom(salesOrder)
+                .leftJoin(salesOrder).on(workOrder.salesOrder.salesOrderSeq.eq(salesOrder.salesOrderSeq))
+                .leftJoin(workOrder).on(productionReceiving.workOrder.workOrderSeq.eq(workOrder.workOrderSeq))
+                .where(productionReceiving.productionReceivingSeq.eq(productionReceivingSeq))
+                .fetchOne();
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/workOrder/command/domain/aggregate/entity/WorkOrder.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/workOrder/command/domain/aggregate/entity/WorkOrder.java
@@ -23,23 +23,23 @@ public class WorkOrder {
     private Long workOrderSeq;
     
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JoinColumn(name = "client_seq")
+    @JoinColumn(name = "clientSeq")
     private Client client; // 거래처(납품처)
 
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_seq")
+    @JoinColumn(name = "userSeq")
     private User user; // 작업지시서 담당자
 
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JoinColumn(name = "sales_order_seq")
+    @JoinColumn(name = "salesOrderSeq")
     private SalesOrder salesOrder; // 주문서
 
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JoinColumn(name = "warehouse_seq")
+    @JoinColumn(name = "warehouseSeq")
     private Warehouse warehouse; // 창고
 
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JoinColumn(name = "item_seq")
+    @JoinColumn(name = "itemSeq")
     private Item item; // 품목
 
     private String workOrderName; // 작업지시서 명

--- a/SCM/backend/src/test/java/error/pirate/backend/productionReceiving/command/application/service/ProductionReceivingServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/productionReceiving/command/application/service/ProductionReceivingServiceTest.java
@@ -69,11 +69,11 @@ class ProductionReceivingServiceTest {
         itemArguments.add(new ProductionReceivingItemDTO(3L, 50, 10000, "만원짜리 음식2"));
 
         return Stream.of(
-                arguments(21L, 2L, 12L, "2024/12/08-1-수정", 2000000, "수정한 생산입고", null, itemArguments),
-                arguments(2L, null, null, null, null, "수정한 생산입고", null, null),
-                arguments(3L, null, null, "2024/12/08-1-수정", null, null, null, itemArguments),
-                arguments(4L, 2L, 12L, "2024/12/08-1-수정", 2000000, "수정한 생산입고", null, null),
-                arguments(5L, null, null, null, null, null, ProductionReceivingStatus.AFTER, null)
+                arguments(21L, 2L, 12L, "2024/12/08-1-수정", 2000000, "수정한 생산입고", itemArguments),
+                arguments(2L, null, null, null, null, "수정한 생산입고", null),
+                arguments(3L, null, null, "2024/12/08-1-수정", null, null, itemArguments),
+                arguments(4L, 2L, 12L, "2024/12/08-1-수정", 2000000, "수정한 생산입고", null),
+                arguments(5L, null, null, null, null, null, null)
         );
     }
 
@@ -83,15 +83,13 @@ class ProductionReceivingServiceTest {
     void updateProductionReceiving(Long productionReceivingSeq,
                                      Long productionWarehouseSeq, Long storeWarehouseSeq,
                                      String productionReceivingName, Integer productionReceivingExtendedPrice,
-                                     String productionReceivingNote, ProductionReceivingStatus productionReceivingStatus,
-                                   List<ProductionReceivingItemDTO> productionReceivingItemList) {
+                                     String productionReceivingNote, List<ProductionReceivingItemDTO> productionReceivingItemList) {
 
         ProductionReceivingUpdateRequest request = new ProductionReceivingUpdateRequest(
                 productionWarehouseSeq,
                 storeWarehouseSeq,
                 productionReceivingName,
                 productionReceivingExtendedPrice,
-                productionReceivingStatus,
                 productionReceivingNote,
                 productionReceivingItemList
         );

--- a/SCM/backend/src/test/java/error/pirate/backend/productionReceiving/command/application/service/ProductionReceivingServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/productionReceiving/command/application/service/ProductionReceivingServiceTest.java
@@ -112,4 +112,36 @@ class ProductionReceivingServiceTest {
 
         assertDoesNotThrow(() -> productionReceivingService.deleteProductionReceiving(productionReceivingSeq));
     }
+
+    private static Stream<Arguments> updateProductionReceivingApprovalParam() {
+
+        return Stream.of(
+                arguments(8L),
+                arguments(10L)
+        );
+    }
+
+    @DisplayName("생산입고 결재")
+    @ParameterizedTest()
+    @MethodSource("updateProductionReceivingApprovalParam")
+    void updateProductionReceivingApproval(Long productionReceivingSeq) {
+
+        assertDoesNotThrow(() -> productionReceivingService.updateProductionReceivingApproval(productionReceivingSeq));
+    }
+
+    private static Stream<Arguments> updateProductionReceivingCompleteParam() {
+
+        return Stream.of(
+                arguments(9L),
+                arguments(11L)
+        );
+    }
+
+    @DisplayName("생산입고 완료")
+    @ParameterizedTest()
+    @MethodSource("updateProductionReceivingCompleteParam")
+    void updateProductionReceivingComplete(Long productionReceivingSeq) {
+
+        assertDoesNotThrow(() -> productionReceivingService.updateProductionReceivingApproval(productionReceivingSeq));
+    }
 }


### PR DESCRIPTION
## 📝 PR 설명
생산입고 상태 변경(결재완료, 생산입고완료)

### 📌 관련 이슈
- **해결할 이슈**: Closes #105

### 변경 사항
- **핵심 변경 내용**: 생산입고 상태 변경 구현 (결재완료, 생산입고완료)

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [x] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4ce778fc-673d-40d1-8840-afcc4dbf3d9d)

### 📄 참고 사항
생산입고 완료 시 -> 생산입고 상태를 생산완료로 변경 -> 주문서 상태를 생산완료로 변경 -> 품목재고에 생산된 양만큼 추가
