### PR TITLE
feat: 품목 조회 기능 구현

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/BomItemRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/BomItemRepository.java
@@ -5,6 +5,10 @@ import error.pirate.backend.item.command.domain.aggregate.entity.BomItem;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BomItemRepository extends JpaRepository<BomItem, Long> {
     void deleteAllByParentItem(Item item);
+
+    List<BomItem> findAllByParentItem(Item parentItem);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/ItemInventoryRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/command/domain/repository/ItemInventoryRepository.java
@@ -1,7 +1,11 @@
 package error.pirate.backend.item.command.domain.repository;
 
+import error.pirate.backend.item.command.domain.aggregate.entity.Item;
 import error.pirate.backend.item.command.domain.aggregate.entity.ItemInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItemInventoryRepository extends JpaRepository<ItemInventory, Long> {
+    List<ItemInventory> findAllByItem(Item item);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/item/query/controller/ItemQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/query/controller/ItemQueryController.java
@@ -1,5 +1,6 @@
 package error.pirate.backend.item.query.controller;
 
+import error.pirate.backend.item.query.dto.ItemDetailResponse;
 import error.pirate.backend.item.query.dto.ItemFilterRequest;
 import error.pirate.backend.item.query.dto.ItemDTO;
 import error.pirate.backend.item.query.service.ItemQueryService;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,15 +19,23 @@ import java.util.List;
 @RequestMapping("/api/v1/item")
 @RequiredArgsConstructor
 @Tag(name = "품목 관리", description = "품목 관리 API")
-public class ItemQueryContoller {
+public class ItemQueryController {
 
     private final ItemQueryService itemQueryService;
 
     @GetMapping
-    @Operation(summary = "품목 검색", description = "품목을 검색한다.")
+    @Operation(summary = "품목 조회", description = "품목을 조회한다.")
     public ResponseEntity<List<ItemDTO>> readItemList(ItemFilterRequest itemFilterRequest) {
-        List<ItemDTO> itemDTO = itemQueryService.readItemList(itemFilterRequest);
-        return ResponseEntity.ok(itemDTO);
+        List<ItemDTO> itemList = itemQueryService.readItemList(itemFilterRequest);
+        return ResponseEntity.ok(itemList);
+    }
+
+    @GetMapping("/{itemSeq}")
+    @Operation(summary = "품목 상세조회", description = "품목을 상세 조회한다.")
+    public ResponseEntity<ItemDetailResponse> readItem(@PathVariable Long itemSeq) {
+        ItemDetailResponse itemDetailResponse = itemQueryService.readItem(itemSeq);
+
+        return ResponseEntity.ok(itemDetailResponse);
     }
 }
 

--- a/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/BomItemQueryDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/BomItemQueryDTO.java
@@ -1,0 +1,4 @@
+package error.pirate.backend.item.query.dto;
+
+public class BomItemQueryDTO {
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/ItemDetailResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/ItemDetailResponse.java
@@ -1,0 +1,16 @@
+package error.pirate.backend.item.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class ItemDetailResponse {
+    ItemDTO itemDTO;
+    List<ItemDTO> childItemList;
+    List<ItemInventoryDTO> itemInventoryList;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/ItemInventoryDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/query/dto/ItemInventoryDTO.java
@@ -1,0 +1,4 @@
+package error.pirate.backend.item.query.dto;
+
+public class ItemInventoryDTO {
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/item/query/service/ItemQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/item/query/service/ItemQueryService.java
@@ -1,11 +1,23 @@
 package error.pirate.backend.item.query.service;
 
+import error.pirate.backend.exception.CustomException;
+import error.pirate.backend.exception.ErrorCodeType;
+import error.pirate.backend.item.command.domain.aggregate.entity.BomItem;
+import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.item.command.domain.aggregate.entity.ItemInventory;
+import error.pirate.backend.item.command.domain.repository.BomItemRepository;
+import error.pirate.backend.item.command.domain.repository.ItemInventoryRepository;
+import error.pirate.backend.item.command.domain.repository.ItemRepository;
 import error.pirate.backend.item.query.dto.ItemDTO;
+import error.pirate.backend.item.query.dto.ItemDetailResponse;
 import error.pirate.backend.item.query.dto.ItemFilterRequest;
+import error.pirate.backend.item.query.dto.ItemInventoryDTO;
 import error.pirate.backend.item.query.mapper.ItemMapper;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -13,6 +25,10 @@ import java.util.List;
 public class ItemQueryService {
 
     private final ItemMapper itemMapper;
+    private final ItemRepository itemRepository;
+    private final ItemInventoryRepository itemInventoryRepository;
+    private final BomItemRepository bomItemRepository;
+    private final ModelMapper modelMapper;
 
     public List<ItemDTO> readItemList(ItemFilterRequest itemFilterRequest) {
         int offset = itemFilterRequest.getSize() * (itemFilterRequest.getPage() - 1) ;
@@ -26,5 +42,28 @@ public class ItemQueryService {
                 offset,
                 itemFilterRequest.getSize()
         );
+    }
+
+    public ItemDetailResponse readItem(Long itemSeq) {
+        Item item = itemRepository.findById(itemSeq).orElseThrow(() -> new CustomException(ErrorCodeType.ITEM_NOT_FOUND));
+
+        ItemDTO itemDTO = modelMapper.map(item, ItemDTO.class);
+
+        List<ItemDTO> childItemList = new ArrayList<>();
+        List<ItemInventoryDTO> itemInventoryList = new ArrayList<>();
+
+        List<BomItem> bomItems = bomItemRepository.findAllByParentItem(item);
+        for(BomItem bomItem : bomItems) {
+            Item childItem = itemRepository.findById(bomItem.getChildItem().getItemSeq()).orElseThrow(() -> new CustomException(ErrorCodeType.ITEM_NOT_FOUND));
+
+            childItemList.add(modelMapper.map(childItem, ItemDTO.class));
+        }
+
+        List<ItemInventory> itemInventories = itemInventoryRepository.findAllByItem(item);
+        for(ItemInventory itemInventory : itemInventories) {
+            itemInventoryList.add(modelMapper.map(itemInventory, ItemInventoryDTO.class));
+        }
+
+        return new ItemDetailResponse(itemDTO, childItemList, itemInventoryList);
     }
 }

--- a/SCM/backend/src/test/java/error/pirate/backend/item/query/service/ItemQueryServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/item/query/service/ItemQueryServiceTest.java
@@ -1,0 +1,41 @@
+package error.pirate.backend.item.query.service;
+
+import error.pirate.backend.item.command.application.dto.BomItemDTO;
+import error.pirate.backend.item.command.application.dto.ItemCreateRequest;
+import error.pirate.backend.item.command.application.service.ItemService;
+import error.pirate.backend.item.command.domain.aggregate.entity.ItemDivision;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@SpringBootTest
+@Transactional
+class ItemQueryServiceTest {
+    @Autowired
+    private ItemQueryService itemQueryService;
+
+    private static Stream<Arguments> readItemParam() {
+
+        return Stream.of(
+                arguments(1L),
+                arguments(2L),
+                arguments(3L)
+        );
+    }
+
+    @DisplayName("품목 조회")
+    @ParameterizedTest
+    @MethodSource("readItemParam")
+    void createItemTest(Long itemSeq) {
+        assertDoesNotThrow(() -> itemQueryService.readItem(itemSeq));
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
품목 조회 기능 구현

### 📌 관련 이슈
- **해결할 이슈**: Closes #114 

### 변경 사항
- **핵심 변경 내용**: 품목 조회 기능 구현
- **주요 변경 파일 및 모듈**: item 하위 패키지

### 🔍 상세 설명
- **구현 내용**: 피그마 내용과 같이 품목 조회 시 품목 재고와 BOM 품목을 모두 조회

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [x] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트 추가(품목 조회)

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/79d49ebb-cb4e-440e-a560-24d2bddc672d)

![image](https://github.com/user-attachments/assets/3e848aa8-27c0-49f1-b778-cff4c941d199)


### 📄 참고 사항
추가로 참고할 사항이나, 리뷰어가 알아야 할 특별한 내용이 있다면 작성해주세요.
