### PR TITLE
feat: 출하전표 조회/등록/수정/삭제

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
@@ -25,6 +25,9 @@ public enum ErrorCodeType {
     SHIPPING_INSTRUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_INSTRUCTION_ERROR_001", "출하지시서를 찾을 수 없습니다."),
     SHIPPING_INSTRUCTION_STATE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "SHIPPING_INSTRUCTION_ERROR_002", "출하지시서의 상태를 확인해주세요"),
 
+    // 출하전표 관련 오류
+    SHIPPING_SLIP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_SLIP_ERROR_001", "출하전표를 찾을 수 없습니다."),
+
     // 공통 오류
     COMMON_ERROR(HttpStatus.BAD_REQUEST, "COMMON_ERROR", "오류가 발생하였습니다. 관리자에게 문의 바랍니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "COMMON_ERROR_002", "유효하지 않은 날짜 범위입니다."),

--- a/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
@@ -27,6 +27,7 @@ public enum ErrorCodeType {
 
     // 출하전표 관련 오류
     SHIPPING_SLIP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_SLIP_ERROR_001", "출하전표를 찾을 수 없습니다."),
+    SHIPPING_SLIP_DELETE_STATE(HttpStatus.BAD_REQUEST, "SHIPPING_SLIP_ERROR_002", "이미 삭제된 출하전표입니다."),
 
     // 공통 오류
     COMMON_ERROR(HttpStatus.BAD_REQUEST, "COMMON_ERROR", "오류가 발생하였습니다. 관리자에게 문의 바랍니다."),

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/aggregate/entity/SalesOrder.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/aggregate/entity/SalesOrder.java
@@ -59,4 +59,9 @@ public class SalesOrder {
     public void updateSalesOrderStatus(SalesOrderStatus salesOrderStatus) {
         this.salesOrderStatus = salesOrderStatus;
     }
+
+    // 상태를 변경하는 메소드
+    public void updateStatus(String status) {
+        this.salesOrderStatus = SalesOrderStatus.valueOf(status);
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/service/SalesOrderDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/service/SalesOrderDomainService.java
@@ -20,4 +20,10 @@ public class SalesOrderDomainService {
         return salesOrderRepository.findById(salesOrderSeq)
                 .orElseThrow(() -> new CustomException(ErrorCodeType.SALES_ORDER_NOT_FOUND));
     }
+
+    /* 상태를 수정하는 로직 */
+    public void updateSalesOrderStatus(SalesOrder salesOrder, String status) {
+        /* 수정을 위해 엔터티 정보 변경 */
+        salesOrder.updateStatus(status);
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationService.java
@@ -35,7 +35,7 @@ public class ShippingInstructionApplicationService {
         SalesOrder salesOrder = salesOrderDomainService.findById(shippingInstructionRequest.getSalesOrderSeq());
 
         // 주문서가 생산완료 상태인지 체크
-        shippingInstructionDomainService.checkShippingInstructionSalesOrder(salesOrder);
+        shippingInstructionDomainService.checkSalesOrderStatus(salesOrder);
 
         // 출하지시서 유저는 주문서 작성 유저
         User user = salesOrder.getUser();
@@ -95,7 +95,7 @@ public class ShippingInstructionApplicationService {
         SalesOrder newSalesOrder = salesOrderDomainService.findById(shippingInstructionRequest.getSalesOrderSeq());
 
         // 주문서가 생산완료 상태인지 체크
-        shippingInstructionDomainService.checkShippingInstructionSalesOrder(newSalesOrder);
+        shippingInstructionDomainService.checkSalesOrderStatus(newSalesOrder);
 
         // 출하지시서 유저는 주문서 작성 유저
         User user = newSalesOrder.getUser();

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionDomainService.java
@@ -48,7 +48,7 @@ public class ShippingInstructionDomainService {
     }
 
     /* 주문서 상태가 생산완료인지 체크 */
-    public void checkShippingInstructionSalesOrder(SalesOrder salesOrder) {
+    public void checkSalesOrderStatus(SalesOrder salesOrder) {
         if (!salesOrder.getSalesOrderStatus().equals(SalesOrderStatus.PRODUCTION_COMPLETE)) {
             throw new CustomException(ErrorCodeType.SALES_ORDER_STATE_BAD_REQUEST);
         }
@@ -77,10 +77,10 @@ public class ShippingInstructionDomainService {
         // 서울 기준 현재 날짜 가져오기
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        // yyyy-MM-dd 형식으로 변환
-        String formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        // yyyy/MM/dd 형식으로 변환
+        String formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
 
-        return formattedDate + " - " + (count + 1);
+        return formattedDate + "-" + (count + 1);
     }
 
     /* 총수량 계산 */
@@ -100,7 +100,7 @@ public class ShippingInstructionDomainService {
     /* 출하지시서 번호로 출하지시서 찾기 */
     public ShippingInstruction findByShippingInstructionSeq(Long shippingInstructionSeq) {
         return shippingInstructionRepository.findById(shippingInstructionSeq)
-                .orElseThrow(() -> new CustomException(ErrorCodeType.SALES_ORDER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCodeType.SHIPPING_INSTRUCTION_NOT_FOUND));
     }
 
     /* 도메인 객체를 수정하는 로직 */

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/mapper/ShippingInstructionItemMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/mapper/ShippingInstructionItemMapper.java
@@ -1,5 +1,7 @@
 package error.pirate.backend.shippingInstruction.command.mapper;
 
+import error.pirate.backend.exception.CustomException;
+import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemDTO;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
@@ -31,8 +33,8 @@ public class ShippingInstructionItemMapper {
             Item item = itemMap.get(itemDTO.getItemSeq()); // itemSeq으로 Item 매핑
 
             if (item == null) {
-                // 매핑되지 않은 Item이 있으면 예외 처리 (필요 시 Custom Exception 사용)
-                throw new IllegalArgumentException("Item not found: " + itemDTO.getItemSeq());
+                // 매핑되지 않은 Item이 있으면 예외 처리
+                throw new CustomException(ErrorCodeType.ITEM_NOT_FOUND);
             }
 
             // ShippingInstructionItem 생성 및 리스트에 추가

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
@@ -13,8 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-
 @Tag(name = "출하지시서")
 @RestController
 @RequiredArgsConstructor    // final 을 받은 필드의 생성자를 주입

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionSituationMonthlyTotalDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionSituationMonthlyTotalDTO.java
@@ -1,0 +1,11 @@
+package error.pirate.backend.shippingInstruction.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "출하지시서 월합계 DTO")
+public class ShippingInstructionSituationMonthlyTotalDTO {
+    private String month;  // 월
+    private int monthlyTotal;   // 월합계
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionSituationResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionSituationResponse.java
@@ -11,4 +11,6 @@ import java.util.List;
 @Schema(description = "출하지시서 현황 응답")
 public class ShippingInstructionSituationResponse {
     private List<ShippingInstructionSituationDTO> shippingInstructionSituationList;
+    private List<ShippingInstructionSituationMonthlyTotalDTO> monthlyTotalList;   // 월합계 리스트
+    private int totalQuantity;  // 총합계
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/mapper/ShippingInstructionMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/mapper/ShippingInstructionMapper.java
@@ -21,4 +21,9 @@ public interface ShippingInstructionMapper {
 
     List<ShippingInstructionSituationDTO> selectShippingInstructionSituation(
             @Param("request") ShippingInstructionSituationRequest request);
+
+    List<ShippingInstructionSituationMonthlyTotalDTO> selectMonthlyTotal(
+            @Param("request") ShippingInstructionSituationRequest request);
+
+    int selectTotal(@Param("request") ShippingInstructionSituationRequest request);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
@@ -51,11 +51,21 @@ public class ShippingInstructionQueryService {
     /* 출하지시서 현황 조회 */
     @Transactional(readOnly = true)
     public ShippingInstructionSituationResponse readShippingInstructionSituation(ShippingInstructionSituationRequest request) {
+        // 출하지시서 현황 조회
         List<ShippingInstructionSituationDTO> shippingInstructionSituationList
                 = shippingInstructionMapper.selectShippingInstructionSituation(request);
 
+        // 출하지시서 현황 월합계
+        List<ShippingInstructionSituationMonthlyTotalDTO> monthlyTotalList
+                = shippingInstructionMapper.selectMonthlyTotal(request);
+
+        // 출하전표 현황 총합계
+        int totalQuantity = shippingInstructionMapper.selectTotal(request);
+
         return ShippingInstructionSituationResponse.builder()
                 .shippingInstructionSituationList(shippingInstructionSituationList)
+                .monthlyTotalList(monthlyTotalList)
+                .totalQuantity(totalQuantity)
                 .build();
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/controller/ShippingSlipCommandController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/controller/ShippingSlipCommandController.java
@@ -1,0 +1,58 @@
+package error.pirate.backend.shippingSlip.command.application.controller;
+
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.application.service.ShippingSlipApplicationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "출하전표", description = "출하전표 조회/등록/수정/삭제")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/shipping-slip")
+@Slf4j
+public class ShippingSlipCommandController {
+
+    private final ShippingSlipApplicationService shippingSlipApplicationService;
+
+    // 출하전표 작성
+    @Operation(summary = "출하전표 작성", description = "출하전표를 작성한다.")
+    @PostMapping
+    public ResponseEntity<String> createShippingSlip(
+            @RequestBody ShippingSlipRequest shippingSlipRequest
+    ) {
+
+        shippingSlipApplicationService.createShippingSlip(shippingSlipRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("출하전표 작성성공");
+    }
+
+    // 출하전표 수정
+    @Operation(summary = "출하전표 수정", description = "출하전표를 수정한다.")
+    @PutMapping("/{shippingSlipSeq}")
+    public ResponseEntity<String> updateShippingSlip(
+            @PathVariable Long shippingSlipSeq,
+            @RequestBody ShippingSlipRequest shippingSlipRequest
+    ) {
+
+        shippingSlipApplicationService.updateShippingSlip(shippingSlipSeq, shippingSlipRequest);
+
+        return ResponseEntity.status(HttpStatus.OK).body("출하전표 수정성공");
+    }
+
+    // 출하전표 삭제 - 재작성을 위한 삭제
+    @Operation(summary = "출하전표 삭제", description = "출하전표를 삭제한다.")
+    @DeleteMapping("/{shippingSlipSeq}")
+    public ResponseEntity<String> deleteShippingSlip(
+            @PathVariable Long shippingSlipSeq
+    ) {
+
+        shippingSlipApplicationService.deleteShippingSlip(shippingSlipSeq);
+
+        return ResponseEntity.status(HttpStatus.OK).body("출하전표 삭제 성공");
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipItemDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipItemDTO.java
@@ -1,0 +1,14 @@
+package error.pirate.backend.shippingSlip.command.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "출하전표 품목 DTO")
+public class ShippingSlipItemDTO {
+    private long itemSeq;    // 품목 시퀀스
+    private int shippingSlipItemQuantity;    // 물품 수량
+    private String shippingSlipItemNote;     // 물품 비고
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipRequest.java
@@ -1,0 +1,18 @@
+package error.pirate.backend.shippingSlip.command.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "출하전표 요청 데이터")
+public class ShippingSlipRequest {
+    private LocalDateTime shippingSlipShippingDate; // 출하일
+    private long shippingInstructionSeq;  // 출하지시서 시퀀스
+    private String shippingSlipNote; // 출하전표 비고
+    private List<ShippingSlipItemDTO> shippingSlipItems; // 물품 리스트
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
@@ -2,6 +2,7 @@ package error.pirate.backend.shippingSlip.command.application.service;
 
 import error.pirate.backend.item.command.application.service.ItemService;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.salesOrder.command.domain.service.SalesOrderDomainService;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.service.ShippingInstructionDomainService;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
@@ -28,6 +29,7 @@ public class ShippingSlipApplicationService {
     private final ShippingSlipItemDomainService shippingSlipItemDomainService;
     private final ShippingInstructionDomainService shippingInstructionDomainService;
     private final ItemService itemService;
+    private final SalesOrderDomainService salesOrderDomainService;
 
     /* 출하전표 등록 */
     @Transactional
@@ -79,6 +81,9 @@ public class ShippingSlipApplicationService {
         /* saveAll 로직 실행 */
         List<ShippingSlipItem> shippingSlipItem
                 = shippingSlipItemDomainService.saveShippingSlipItem(newShippingSlipItemList);
+
+        /* 주문서 상태를 출하완료로 변경 */
+        salesOrderDomainService.updateSalesOrderStatus(shippingInstruction.getSalesOrder(), "SHIPMENT_COMPLETE");
     }
 
     /* 출하전표 수정 */
@@ -87,6 +92,9 @@ public class ShippingSlipApplicationService {
         /* 출하전표 찾기 */
         ShippingSlip shippingSlip
                 = shippingSlipDomainService.findByShippingSlipSeq(shippingSlipSeq);
+
+        /* 수정이 가능한 상태인지 체크 */
+        shippingSlipDomainService.checkShippingSlipDeleteStatus(shippingSlip.getShippingSlipStatus());
 
         /* 현재 출하지시서 저장 */
         ShippingInstruction shippingInstruction = shippingSlip.getShippingInstruction();
@@ -151,5 +159,8 @@ public class ShippingSlipApplicationService {
 
         /* 삭제 상태로 변경 */
         shippingSlipDomainService.deleteShippingSlip(shippingSlip);
+
+        /* 주문서 상태를 생산완료로 변경 */
+        salesOrderDomainService.updateSalesOrderStatus(shippingSlip.getShippingInstruction().getSalesOrder(), "PRODUCTION_COMPLETE");
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
@@ -1,0 +1,155 @@
+package error.pirate.backend.shippingSlip.command.application.service;
+
+import error.pirate.backend.item.command.application.service.ItemService;
+import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
+import error.pirate.backend.shippingInstruction.command.domain.service.ShippingInstructionDomainService;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
+import error.pirate.backend.shippingSlip.command.domain.service.ShippingSlipDomainService;
+import error.pirate.backend.shippingSlip.command.domain.service.ShippingSlipItemDomainService;
+import error.pirate.backend.user.command.domain.aggregate.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShippingSlipApplicationService {
+
+    private final ShippingSlipDomainService shippingSlipDomainService;
+    private final ShippingSlipItemDomainService shippingSlipItemDomainService;
+    private final ShippingInstructionDomainService shippingInstructionDomainService;
+    private final ItemService itemService;
+
+    /* 출하전표 등록 */
+    @Transactional
+    public void createShippingSlip(ShippingSlipRequest shippingSlipRequest) {
+        ShippingInstruction shippingInstruction
+                = shippingInstructionDomainService.findByShippingInstructionSeq(shippingSlipRequest.getShippingInstructionSeq());
+
+        // 출하지시서가 결재후 상태인지 체크
+        shippingSlipDomainService.checkShippingInstructionStatus(shippingInstruction);
+
+        // 출하전표 유저는 출하지시서 작성 유저
+        User user = shippingInstruction.getUser();
+
+        /* 출하일을 서울 시간으로 변경 */
+        LocalDateTime shippingSlipShippingDate =
+                shippingSlipDomainService.setShippingSlipShippingDate(
+                        shippingSlipRequest.getShippingSlipShippingDate());
+
+        /* 등록일을 기반으로 ShippingSlip 명 설정 */
+        long count = shippingSlipDomainService.countTodayShippingSlip();
+        String shippingSlipName = shippingSlipDomainService.setShippingSlipName(count);
+
+        /* 총수량 연산 */
+        int itemTotalQuantity = shippingSlipDomainService.calculateTotalQuantity(shippingSlipRequest);
+
+        /* ShippingSlip 도메인 생성 로직 실행, entity 반환 */
+        ShippingSlip newShippingSlip =
+                shippingSlipDomainService.createShippingSlip(
+                        shippingSlipRequest, shippingInstruction, user,
+                        shippingSlipName, shippingSlipShippingDate, itemTotalQuantity
+                );
+
+        /* save 로직 실행 */
+        ShippingSlip shippingSlip =
+                shippingSlipDomainService.saveShippingSlip(newShippingSlip);
+
+        /* 물품 불러오기 */
+        List<Long> itemNameList = shippingSlipRequest.getShippingSlipItems()
+                .stream()
+                .map(ShippingSlipItemDTO::getItemSeq) // itemSeq 필드 추출
+                .toList(); // 추출한 값을 List로 변환
+        List<Item> itemList = itemService.findAllById(itemNameList);
+
+        /* ShippingSlipItem 도메인 생성 로직 실행, entity 반환 */
+        List<ShippingSlipItem> newShippingSlipItemList
+                = shippingSlipItemDomainService.createShippingSlipItemList(
+                        shippingSlipRequest, shippingSlip, itemList);
+
+        /* saveAll 로직 실행 */
+        List<ShippingSlipItem> shippingSlipItem
+                = shippingSlipItemDomainService.saveShippingSlipItem(newShippingSlipItemList);
+    }
+
+    /* 출하전표 수정 */
+    @Transactional
+    public void updateShippingSlip(Long shippingSlipSeq, ShippingSlipRequest shippingSlipRequest) {
+        /* 출하전표 찾기 */
+        ShippingSlip shippingSlip
+                = shippingSlipDomainService.findByShippingSlipSeq(shippingSlipSeq);
+
+        /* 현재 출하지시서 저장 */
+        ShippingInstruction shippingInstruction = shippingSlip.getShippingInstruction();
+
+        // 등록과 동일
+        ShippingInstruction newShippingInstruction
+                = shippingInstructionDomainService.findByShippingInstructionSeq(shippingSlipRequest.getShippingInstructionSeq());
+
+        // 출하지시서가 결재후 상태인지 체크
+        shippingSlipDomainService.checkShippingInstructionStatus(newShippingInstruction);
+
+        // 출하전표 유저는 출하지시서 작성 유저
+        User user = newShippingInstruction.getUser();
+
+        /* 출하일을 서울 시간으로 변경 */
+        LocalDateTime shippingSlipShippingDate =
+                shippingSlipDomainService.setShippingSlipShippingDate(
+                        shippingSlipRequest.getShippingSlipShippingDate());
+
+        /* 총수량 연산 */
+        int itemTotalQuantity = shippingSlipDomainService.calculateTotalQuantity(shippingSlipRequest);
+
+        /* ShippingInstruction 도메인 수정 로직 실행 */
+        ShippingSlip newShippingSlip =
+                shippingSlipDomainService.updateShippingSlip(
+                        shippingSlip, shippingSlipRequest, newShippingInstruction, user,
+                        shippingSlipShippingDate, itemTotalQuantity
+                );
+
+        /* 출하지시서가 변경되었는지 체크 */
+        boolean changeShippingInstruction =
+                shippingSlipDomainService.checkChangedShippingInstruction(shippingInstruction, newShippingInstruction);
+
+        /* 출하지시서가 변경되었다면 출하전표 품목도 변경*/
+        if (changeShippingInstruction){
+            /* 물품 불러오기 */
+            List<Long> itemNameList = shippingSlipRequest.getShippingSlipItems()
+                    .stream()
+                    .map(ShippingSlipItemDTO::getItemSeq) // itemSeq 필드 추출
+                    .toList(); // 추출한 값을 List로 변환
+            List<Item> itemList = itemService.findAllById(itemNameList);
+
+            /* 기존에 저장된 출하전표 품목 리스트 삭제 */
+            shippingSlipItemDomainService.deleteByShippingSlip(newShippingSlip);
+
+            /* ShippingSlipItem 도메인 생성 로직 실행, entity 반환 */
+            List<ShippingSlipItem> newShippingSlipItemList
+                    = shippingSlipItemDomainService.createShippingSlipItemList(
+                            shippingSlipRequest, newShippingSlip, itemList);
+
+            /* saveAll 로직 실행 */
+            List<ShippingSlipItem> shippingSlipItem
+                    = shippingSlipItemDomainService.saveShippingSlipItem(newShippingSlipItemList);
+        }
+    }
+
+    /* 출하전표 삭제 */
+    @Transactional
+    public void deleteShippingSlip(Long shippingSlipSeq) {
+        /* 출하전표 찾기 */
+        ShippingSlip shippingSlip = shippingSlipDomainService.findByShippingSlipSeq(shippingSlipSeq);
+
+        /* 삭제 상태로 변경 */
+        shippingSlipDomainService.deleteShippingSlip(shippingSlip);
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlip.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlip.java
@@ -33,6 +33,9 @@ public class ShippingSlip {
 
     private String shippingSlipAddress; // 출하전표 주소
 
+    @Enumerated(EnumType.STRING)
+    private ShippingSlipStatus shippingSlipStatus; // 출하전표 상태
+
     @CreatedDate
     private LocalDateTime shippingSlipRegDate; // 출하전표 등록일
 

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlip.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlip.java
@@ -48,4 +48,33 @@ public class ShippingSlip {
     private Integer shippingSlipTotalQuantity; // 출하전표 총 수량
 
     private String shippingSlipNote; // 출하전표 비고
+
+    private ShippingSlip(ShippingInstruction shippingInstruction, User user, String shippingSlipName, String shippingInstructionAddress, LocalDateTime shippingSlipShippingDate, int itemTotalQuantity, String shippingSlipNote){
+        this.shippingInstruction = shippingInstruction;
+        this.user = user;
+        this.shippingSlipName = shippingSlipName;
+        this.shippingSlipAddress = shippingInstructionAddress;
+        this.shippingSlipShippingDate = shippingSlipShippingDate;
+        this.shippingSlipTotalQuantity = itemTotalQuantity;
+        this.shippingSlipNote = shippingSlipNote;
+    }
+
+    public static ShippingSlip create(ShippingInstruction shippingInstruction, User user, String shippingSlipName, String shippingSlipAddress, LocalDateTime shippingSlipShippingDate, int itemTotalQuantity, String shippingSlipNote) {
+        return new ShippingSlip(shippingInstruction, user, shippingSlipName, shippingSlipAddress, shippingSlipShippingDate, itemTotalQuantity, shippingSlipNote);
+    }
+
+    // 다른 필드를 변경하는 메소드
+    public void update(ShippingInstruction shippingInstruction, User user, String shippingInstructionAddress, LocalDateTime shippingSlipShippingDate, int itemTotalQuantity, String shippingSlipNote) {
+        this.shippingInstruction = shippingInstruction;
+        this.user = user;
+        this.shippingSlipAddress = shippingInstructionAddress;
+        this.shippingSlipShippingDate = shippingSlipShippingDate;
+        this.shippingSlipTotalQuantity = itemTotalQuantity;
+        this.shippingSlipNote = shippingSlipNote;
+    }
+
+    // 상태를 변경하는 메소드
+    public void updateStatus(String status) {
+        this.shippingSlipStatus = ShippingSlipStatus.valueOf(status);
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlipItem.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlipItem.java
@@ -24,5 +24,16 @@ public class ShippingSlipItem {
 
     private int shippingSlipItemQuantity; // 출하전표 품목 수량
 
-    private String shippingSlipItemNote; // 찰하전표 품목 비고
+    private String shippingSlipItemNote; // 출하전표 품목 비고
+
+    private ShippingSlipItem(ShippingSlip shippingSlip, Item item, int shippingSlipItemQuantity, String shippingSlipItemNote) {
+        this.shippingSlip = shippingSlip;
+        this.item = item;
+        this.shippingSlipItemQuantity = shippingSlipItemQuantity;
+        this.shippingSlipItemNote = shippingSlipItemNote;
+    }
+
+    public static ShippingSlipItem create(ShippingSlip shippingSlip, Item item, int shippingSlipItemQuantity, String shippingSlipItemNote) {
+        return new ShippingSlipItem(shippingSlip, item, shippingSlipItemQuantity, shippingSlipItemNote);
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlipStatus.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/aggregate/entity/ShippingSlipStatus.java
@@ -1,0 +1,5 @@
+package error.pirate.backend.shippingSlip.command.domain.aggregate.entity;
+
+public enum ShippingSlipStatus {
+    DELETE  // 삭제
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/repository/ShippingSlipItemRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/repository/ShippingSlipItemRepository.java
@@ -1,0 +1,9 @@
+package error.pirate.backend.shippingSlip.command.domain.repository;
+
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShippingSlipItemRepository extends JpaRepository<ShippingSlipItem, Long> {
+    void deleteByShippingSlip(ShippingSlip newShippingSlip);
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/repository/ShippingSlipRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/repository/ShippingSlipRepository.java
@@ -1,0 +1,10 @@
+package error.pirate.backend.shippingSlip.command.domain.repository;
+
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface ShippingSlipRepository extends JpaRepository<ShippingSlip, Long> {
+    long countByShippingSlipRegDateBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
@@ -7,6 +7,7 @@ import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipStatus;
 import error.pirate.backend.shippingSlip.command.domain.repository.ShippingSlipRepository;
 import error.pirate.backend.shippingSlip.command.mapper.ShippingSlipMapper;
 import error.pirate.backend.user.command.domain.aggregate.entity.User;
@@ -122,6 +123,14 @@ public class ShippingSlipDomainService {
         return shippingSlip;
     }
 
+    /* 출하전표 수정이 가능한 상태인지 체크 */
+    public void checkShippingSlipDeleteStatus(ShippingSlipStatus shippingSlipStatus) {
+        /* 삭제 상태라면 변경 불가*/
+        if (shippingSlipStatus.equals(ShippingSlipStatus.DELETE)) {
+            throw new CustomException(ErrorCodeType.SHIPPING_SLIP_DELETE_STATE);
+        }
+    }
+
     /* 출하지시서가 변경되었는지 체크 */
     public boolean checkChangedShippingInstruction(ShippingInstruction shippingInstruction, ShippingInstruction newShippingInstruction) {
         return !Objects.equals(
@@ -133,4 +142,6 @@ public class ShippingSlipDomainService {
         /* 수정을 위해 엔터티 정보 변경 */
         shippingSlip.updateStatus("DELETE");
     }
+
+
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
@@ -1,0 +1,136 @@
+package error.pirate.backend.shippingSlip.command.domain.service;
+
+import error.pirate.backend.exception.CustomException;
+import error.pirate.backend.exception.ErrorCodeType;
+import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
+import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionStatus;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.repository.ShippingSlipRepository;
+import error.pirate.backend.shippingSlip.command.mapper.ShippingSlipMapper;
+import error.pirate.backend.user.command.domain.aggregate.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShippingSlipDomainService {
+
+    private final ShippingSlipRepository shippingSlipRepository;
+
+    /* 도메인 객체를 생성하는 로직 */
+    public ShippingSlip createShippingSlip(
+            ShippingSlipRequest shippingSlipRequest,
+            ShippingInstruction shippingInstruction, User user, String shippingInstructionName,
+            LocalDateTime shippingSlipShippingDate,
+            int itemTotalQuantity) {
+
+        /* dto to entity */
+        ShippingSlip newShippingSlip = ShippingSlipMapper.toEntity(
+                shippingSlipRequest, shippingInstruction, user, shippingInstructionName,
+                shippingSlipShippingDate, itemTotalQuantity);
+        return newShippingSlip;
+    }
+
+    /* 도메인 객체를 저장하는 로직 */
+    public ShippingSlip saveShippingSlip(ShippingSlip newShippingSlip) {
+        return shippingSlipRepository.save(newShippingSlip);
+    }
+
+    /* 출하지시서가 결재후 상태인지 체크 */
+    public void checkShippingInstructionStatus(ShippingInstruction shippingInstruction) {
+        if (!shippingInstruction.getShippingInstructionStatus().equals(ShippingInstructionStatus.AFTER)) {
+            throw new CustomException(ErrorCodeType.SHIPPING_INSTRUCTION_STATE_BAD_REQUEST);
+        }
+    }
+
+    /* 출하일 서울시간 설정 */
+    public LocalDateTime setShippingSlipShippingDate(LocalDateTime shippingSlipShippingDate) {
+        ZonedDateTime systemZonedDateTime = shippingSlipShippingDate.atZone(ZoneId.systemDefault());
+        ZonedDateTime seoulZonedDateTime = systemZonedDateTime.withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+        return seoulZonedDateTime.toLocalDateTime();
+    }
+
+    /* 오늘날짜의 등록된 출하전표 갯수 찾기 */
+    public long countTodayShippingSlip() {
+        // 서울 시간대(Asia/Seoul)를 지정하여 시작과 끝 시간 생성
+        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
+
+        // 서울 시간대 기준으로 오늘의 시작과 끝 시간을 계산
+        LocalDateTime startOfDay = LocalDate.now(seoulZoneId).atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+        return shippingSlipRepository.countByShippingSlipRegDateBetween(startOfDay, endOfDay);
+    }
+
+    /* 출하전표 이름 설정 */
+    public String setShippingSlipName(long count) {
+        // 서울 기준 현재 날짜 가져오기
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        // yyyy/MM/dd 형식으로 변환
+        String formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+
+        return formattedDate + "-" + (count + 1);
+    }
+
+    /* 총수량 계산 */
+    public int calculateTotalQuantity(ShippingSlipRequest request) {
+        // Null 검사를 수행하여 NPE 방지
+        if (request.getShippingSlipItems() == null || request.getShippingSlipItems().isEmpty()) {
+            return 0;
+        }
+
+        // stream을 사용해 shippingSlipItemQuantity 필드 합산
+        return request.getShippingSlipItems()
+                .stream()
+                .mapToInt(ShippingSlipItemDTO::getShippingSlipItemQuantity)
+                .sum();
+    }
+
+    /* 출하전표 번호로 출하전표 찾기 */
+    public ShippingSlip findByShippingSlipSeq(Long shippingSlipSeq) {
+        return shippingSlipRepository.findById(shippingSlipSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.SHIPPING_SLIP_NOT_FOUND));
+    }
+
+    /* 도메인 객체를 수정하는 로직 */
+    public ShippingSlip updateShippingSlip(
+            ShippingSlip shippingSlip, ShippingSlipRequest shippingSlipRequest,
+            ShippingInstruction shippingInstruction, User user,
+            LocalDateTime shippingSlipShippingDate, int itemTotalQuantity) {
+
+        /* 수정을 위해 엔터티 정보 변경 */
+        shippingSlip.update(
+                shippingInstruction,
+                user,
+                shippingInstruction.getShippingInstructionAddress(),
+                shippingSlipShippingDate,
+                itemTotalQuantity,
+                shippingSlipRequest.getShippingSlipNote()
+        );
+
+        return shippingSlip;
+    }
+
+    /* 출하지시서가 변경되었는지 체크 */
+    public boolean checkChangedShippingInstruction(ShippingInstruction shippingInstruction, ShippingInstruction newShippingInstruction) {
+        return !Objects.equals(
+                shippingInstruction.getShippingInstructionSeq(), newShippingInstruction.getShippingInstructionSeq());
+    }
+
+    /* 도메인 객체를 삭제 로직 */
+    public void deleteShippingSlip(ShippingSlip shippingSlip) {
+        /* 수정을 위해 엔터티 정보 변경 */
+        shippingSlip.updateStatus("DELETE");
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipItemDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipItemDomainService.java
@@ -1,0 +1,45 @@
+package error.pirate.backend.shippingSlip.command.domain.service;
+
+import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
+import error.pirate.backend.shippingSlip.command.domain.repository.ShippingSlipItemRepository;
+import error.pirate.backend.shippingSlip.command.mapper.ShippingSlipItemMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShippingSlipItemDomainService {
+
+    private final ShippingSlipItemRepository shippingSlipItemRepository;
+
+    /* 도메인 객체를 생성하는 로직 */
+    public List<ShippingSlipItem> createShippingSlipItemList(
+            ShippingSlipRequest shippingSlipRequest,
+            ShippingSlip shippingSlip,
+            List<Item> itemList) {
+
+        /* dto to entity */
+        List<ShippingSlipItem> newShippingSlipItems = ShippingSlipItemMapper.toEntity(
+                shippingSlipRequest, shippingSlip, itemList
+        );
+
+        return newShippingSlipItems;
+    }
+
+    /* 도메인 객체를 저장하는 로직 */
+    public List<ShippingSlipItem> saveShippingSlipItem(List<ShippingSlipItem> newShippingSlipItemList) {
+        return shippingSlipItemRepository.saveAll(newShippingSlipItemList);
+    }
+
+    /* 출하지시서 번호로 도메인 객체 삭제하는 로직 */
+    public void deleteByShippingSlip(ShippingSlip newShippingSlip) {
+        shippingSlipItemRepository.deleteByShippingSlip(newShippingSlip);
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipItemMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipItemMapper.java
@@ -1,0 +1,52 @@
+package error.pirate.backend.shippingSlip.command.mapper;
+
+import error.pirate.backend.exception.CustomException;
+import error.pirate.backend.exception.ErrorCodeType;
+import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ShippingSlipItemMapper {
+    public static List<ShippingSlipItem> toEntity(
+            ShippingSlipRequest shippingSlipRequest,
+            ShippingSlip shippingSlip,
+            List<Item> itemList) {
+
+        List<ShippingSlipItem> shippingSlipItemList = new ArrayList<>();
+
+        // shippingSlipRequest에서 shippingSlipItems 가져오기
+        List<ShippingSlipItemDTO> itemDTOList  = shippingSlipRequest.getShippingSlipItems();
+
+        // itemList를 Map으로 변환하여 매핑 속도 향상
+        Map<Long, Item> itemMap = itemList.stream()
+                .collect(Collectors.toMap(Item::getItemSeq, item -> item));
+
+        // DTO 리스트를 순회하며 ShippingInstructionItem 생성
+        for (ShippingSlipItemDTO itemDTO : itemDTOList) {
+            Item item = itemMap.get(itemDTO.getItemSeq()); // itemSeq으로 Item 매핑
+
+            if (item == null) {
+                // 매핑되지 않은 Item이 있으면 예외 처리
+                throw new CustomException(ErrorCodeType.ITEM_NOT_FOUND);
+            }
+
+            // ShippingSlipItem 생성 및 리스트에 추가
+            ShippingSlipItem shippingSlipItem = ShippingSlipItem.create(
+                    shippingSlip, // ShippingSlip 객체
+                    item, // Item 객체
+                    itemDTO.getShippingSlipItemQuantity(), // 수량
+                    itemDTO.getShippingSlipItemNote() // 비고
+            );
+            shippingSlipItemList.add(shippingSlipItem);
+        }
+
+        return shippingSlipItemList;
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipMapper.java
@@ -1,0 +1,25 @@
+package error.pirate.backend.shippingSlip.command.mapper;
+
+import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
+import error.pirate.backend.user.command.domain.aggregate.entity.User;
+
+import java.time.LocalDateTime;
+
+public class ShippingSlipMapper {
+    public static ShippingSlip toEntity(
+            ShippingSlipRequest shippingSlipRequest, ShippingInstruction shippingInstruction,
+            User user, String shippingSlipName,
+            LocalDateTime shippingSlipShippingDate, int itemTotalQuantity) {
+        return ShippingSlip.create(
+                shippingInstruction,
+                user,
+                shippingSlipName,
+                shippingInstruction.getShippingInstructionAddress(),
+                shippingSlipShippingDate,
+                itemTotalQuantity,
+                shippingSlipRequest.getShippingSlipNote()
+        );
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/controller/ShippingSlipQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/controller/ShippingSlipQueryController.java
@@ -1,0 +1,52 @@
+package error.pirate.backend.shippingSlip.query.controller;
+
+import error.pirate.backend.shippingSlip.query.dto.*;
+import error.pirate.backend.shippingSlip.query.service.ShippingSlipQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "출하전표")
+@RestController
+@RequiredArgsConstructor    // final 을 받은 필드의 생성자를 주입
+@RequestMapping("/api/v1/shipping-slip")
+@Slf4j
+public class ShippingSlipQueryController {
+    private final ShippingSlipQueryService shippingSlipQueryService;
+
+    @Operation(summary = "출하전표 조회", description = "출하전표 조회")
+    @GetMapping
+    public ResponseEntity<ShippingSlipListResponse> readShippingSlipList(
+            @ModelAttribute ShippingSlipListRequest request
+    ) {
+        ShippingSlipListResponse response
+                = shippingSlipQueryService.readShippingSlipList(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "출하전표 상세조회", description = "출하전표 상세조회")
+    @GetMapping("/{shippingSlipSeq}")
+    public ResponseEntity<ShippingSlipResponse> readShippingSlip(
+            @PathVariable long shippingSlipSeq
+    ) {
+        ShippingSlipResponse response
+                = shippingSlipQueryService.readShippingSlip(shippingSlipSeq);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "출하전표 현황 조회", description = "출하전표 현황 조회")
+    @GetMapping("/situation")
+    public ResponseEntity<ShippingSlipSituationResponse> readShippingSlipSituation(
+            @ModelAttribute ShippingSlipSituationRequest request
+    ) {
+        ShippingSlipSituationResponse response
+                = shippingSlipQueryService.readShippingSlipSituation(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipDTO.java
@@ -1,0 +1,19 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Schema(description = "출하전표 DTO")
+public class ShippingSlipDTO {
+    private long shippingSlipSeq;    // 출하전표 번호
+    private String shippingSlipName; // 출하전표명
+    private LocalDateTime shippingSlipShippingDate; // 출하일
+    private String clientName;  // 거래처명
+    private int shippingSlipTotalQuantity;   // 출하전표 총수량
+    private String shippingSlipAddress;  // 출하전표 주소
+    private String userName;    // 출하전표 담당자
+    private String shippingSlipNote; // 출하전표 비고
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipItemDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipItemDTO.java
@@ -1,0 +1,18 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "출하전표 품목 DTO")
+public class ShippingSlipItemDTO {
+    private long shippingSlipItemSeq;    // 출하전표 품목 번호
+    private long itemSeq;   // 품목 번호
+    private String itemImageUrl;    // 품목 이미지 url
+    private String itemName;    // 품목명
+    private String itemDivision;    // 품목 구분
+    private int itemPrice;  // 품목 단가
+    private int shippingSlipItemQuantity;    // 출하전표 품목 수량
+    private String shippingSlipItemNote; // 출하전표 품목 비고
+    private int itemTotalAmount;  // 품목 총금액
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListDTO.java
@@ -1,0 +1,16 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Schema(description = "출하전표 리스트 DTO")
+public class ShippingSlipListDTO {
+    private long shippingSlipSeq;    // 출하전표 번호
+    private String shippingSlipName; // 출하전표명
+    private LocalDate shippingSlipShippingDate; // 출하일
+    private String clientName;  // 거래처명
+    private String itemName;    // 품목명
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListRequest.java
@@ -1,0 +1,21 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "출하전표 리스트 요청")
+public class ShippingSlipListRequest {
+    private int page = 1; // 기본값 설정
+    private int size = 10; // 기본값 설정
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) // LocalDate 매핑을 위해 필요
+    private LocalDate startDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+    private String clientName;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListResponse.java
@@ -1,0 +1,17 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "출하전표 리스트 응답")
+public class ShippingSlipListResponse {
+    private List<ShippingSlipListDTO> shippingSlipList;
+    private int currentPage;            // 현재 페이지
+    private int totalPages;             // 전체 페이지 수
+    private long totalItems;            // 총 아이템 수
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipResponse.java
@@ -1,0 +1,15 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "출하전표 상세 응답")
+public class ShippingSlipResponse {
+    private ShippingSlipDTO shippingSlipDTO;
+    private List<ShippingSlipItemDTO> itemList;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationDTO.java
@@ -1,0 +1,18 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Schema(description = "출하전표 현황 DTO")
+public class ShippingSlipSituationDTO {
+    private long shippingSlipSeq;    // 출하전표 번호
+    private LocalDate shippingSlipShippingDate; // 출하일
+    private String shippingSlipName; // 출하전표명
+    private int shippingSlipTotalQuantity;   // 출하전표 총수량
+    private String clientName;  // 거래처명
+    private String shippingSlipAddress;  // 출하전표 주소
+    private String shippingSlipNote; // 출하전표 비고
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationMonthlyTotalDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationMonthlyTotalDTO.java
@@ -1,0 +1,11 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "출하전표 월합계 DTO")
+public class ShippingSlipSituationMonthlyTotalDTO {
+    private String month;  // 월
+    private int monthlyTotal;   // 월합계
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationRequest.java
@@ -1,0 +1,19 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "출하전표 현황 요청")
+public class ShippingSlipSituationRequest {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+    private String clientName;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationResponse.java
@@ -10,5 +10,7 @@ import java.util.List;
 @Builder
 @Schema(description = "출하전표 현황 응답")
 public class ShippingSlipSituationResponse {
-    private List<ShippingSlipSituationDTO> shippingSlipSituationList;
+    private List<ShippingSlipSituationDTO> shippingSlipSituationList;   // 현황 리스트
+    private List<ShippingSlipSituationMonthlyTotalDTO> monthlyTotalList;   // 월합계 리스트
+    private int totalQuantity;  // 총합계
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationResponse.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipSituationResponse.java
@@ -1,0 +1,14 @@
+package error.pirate.backend.shippingSlip.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "출하전표 현황 응답")
+public class ShippingSlipSituationResponse {
+    private List<ShippingSlipSituationDTO> shippingSlipSituationList;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/mapper/ShippingSlipMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/mapper/ShippingSlipMapper.java
@@ -1,0 +1,24 @@
+package error.pirate.backend.shippingSlip.query.mapper;
+
+import error.pirate.backend.shippingSlip.query.dto.*;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ShippingSlipMapper {
+    List<ShippingSlipListDTO> selectShippingSlipList(
+            @Param("offset") int offset,
+            @Param("request") ShippingSlipListRequest request);
+
+    long countShippingSlip(
+            @Param("request") ShippingSlipListRequest request);
+
+    ShippingSlipDTO selectShippingSlipByShippingSlipSeq(long shippingSlipSeq);
+
+    List<ShippingSlipItemDTO> selectItemListByShippingSlipSeq(long shippingSlipSeq);
+
+    List<ShippingSlipSituationDTO> selectShippingSlipSituation(
+            @Param("request") ShippingSlipSituationRequest request);
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/mapper/ShippingSlipMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/mapper/ShippingSlipMapper.java
@@ -21,4 +21,10 @@ public interface ShippingSlipMapper {
 
     List<ShippingSlipSituationDTO> selectShippingSlipSituation(
             @Param("request") ShippingSlipSituationRequest request);
+
+    List<ShippingSlipSituationMonthlyTotalDTO> selectMonthlyTotal(
+            @Param("request") ShippingSlipSituationRequest request);
+
+    int selectTotal(
+            @Param("request") ShippingSlipSituationRequest request);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
@@ -1,0 +1,60 @@
+package error.pirate.backend.shippingSlip.query.service;
+
+import error.pirate.backend.shippingSlip.query.dto.*;
+import error.pirate.backend.shippingSlip.query.mapper.ShippingSlipMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShippingSlipQueryService {
+
+    private final ShippingSlipMapper shippingSlipMapper;
+
+    /* 출하전표 리스트 조회 */
+    @Transactional(readOnly = true)
+    public ShippingSlipListResponse readShippingSlipList(ShippingSlipListRequest request) {
+        int offset = (request.getPage() - 1) * request.getSize();
+        List<ShippingSlipListDTO> shippingSlipList
+                = shippingSlipMapper.selectShippingSlipList(offset, request);
+
+        long totalItems = shippingSlipMapper.countShippingSlip(request);
+
+        return ShippingSlipListResponse.builder()
+                .shippingSlipList(shippingSlipList)
+                .currentPage(request.getPage())
+                .totalPages((int) Math.ceil((double) totalItems / request.getSize()))
+                .totalItems(totalItems)
+                .build();
+    }
+
+    /* 출하전표 상세 조회 */
+    @Transactional(readOnly = true)
+    public ShippingSlipResponse readShippingSlip(long shippingSlipSeq) {
+        // 품목을 제외한 출하전표 조회
+        ShippingSlipDTO shippingSlip = shippingSlipMapper.selectShippingSlipByShippingSlipSeq(shippingSlipSeq);
+
+        // 출하전표에 해당하는 품목 리스트 조회
+        List<ShippingSlipItemDTO> itemList
+                = shippingSlipMapper.selectItemListByShippingSlipSeq(shippingSlipSeq);
+
+        return ShippingSlipResponse.builder()
+                .shippingSlipDTO(shippingSlip)
+                .itemList(itemList)
+                .build();
+    }
+
+    /* 출하전표 현황 조회 */
+    @Transactional(readOnly = true)
+    public ShippingSlipSituationResponse readShippingSlipSituation(ShippingSlipSituationRequest request) {
+        List<ShippingSlipSituationDTO> shippingSlipSituationList
+                = shippingSlipMapper.selectShippingSlipSituation(request);
+
+        return ShippingSlipSituationResponse.builder()
+                .shippingSlipSituationList(shippingSlipSituationList)
+                .build();
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
@@ -50,11 +50,21 @@ public class ShippingSlipQueryService {
     /* 출하전표 현황 조회 */
     @Transactional(readOnly = true)
     public ShippingSlipSituationResponse readShippingSlipSituation(ShippingSlipSituationRequest request) {
+        // 출하전표 현황 조회
         List<ShippingSlipSituationDTO> shippingSlipSituationList
                 = shippingSlipMapper.selectShippingSlipSituation(request);
 
+        // 출하전표 현황 월합계
+        List<ShippingSlipSituationMonthlyTotalDTO> monthlyTotalList
+                = shippingSlipMapper.selectMonthlyTotal(request);
+
+        // 출하전표 현황 총합계
+        int totalQuantity = shippingSlipMapper.selectTotal(request);
+
         return ShippingSlipSituationResponse.builder()
                 .shippingSlipSituationList(shippingSlipSituationList)
+                .monthlyTotalList(monthlyTotalList)
+                .totalQuantity(totalQuantity)
                 .build();
     }
 }

--- a/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
@@ -36,6 +36,7 @@
         <if test="request.shippingInstructionStatus != '' and request.shippingInstructionStatus != null">
             AND si.shipping_instruction_status LIKE #{request.shippingInstructionStatus}
         </if>
+        ORDER BY si.shipping_instruction_reg_date DESC
         LIMIT #{request.size} OFFSET #{offset}
     </select>
 

--- a/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
@@ -23,7 +23,8 @@
         FROM tb_shipping_instruction si
         JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
         JOIN tb_client c ON (so.client_seq = c.client_seq)
-        WHERE si.shipping_instruction_status IN ('BEFORE', 'AFTER')
+        WHERE si.shipping_instruction_status NOT IN ('DELETE')
+        OR si.shipping_instruction_status IS NULL
         <if test="request.startDate != null"><![CDATA[
             AND #{request.startDate} <= si.shipping_instruction_scheduled_shipment_date
              ]]></if>
@@ -46,7 +47,8 @@
         FROM tb_shipping_instruction si
         JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
         JOIN tb_client c ON (so.client_seq = c.client_seq)
-        WHERE si.shipping_instruction_status IN ('BEFORE', 'AFTER')
+        WHERE si.shipping_instruction_status NOT IN ('DELETE')
+        OR si.shipping_instruction_status IS NULL
         <if test="request.startDate != null"><![CDATA[
             AND #{request.startDate} <= si.shipping_instruction_scheduled_shipment_date
              ]]></if>
@@ -113,13 +115,57 @@
         FROM tb_shipping_instruction si
         JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
         JOIN tb_client c ON (so.client_seq = c.client_seq)
-        WHERE si.shipping_instruction_status IN ('BEFORE', 'AFTER')
+        WHERE si.shipping_instruction_status NOT IN ('DELETE')
+        OR si.shipping_instruction_status IS NULL
         <if test="request.startDate != null"><![CDATA[
             AND #{request.startDate} <= si.shipping_instruction_scheduled_shipment_date
         ]]></if>
         <if test="request.endDate != null"><![CDATA[
             AND #{request.endDate} >= si.shipping_instruction_scheduled_shipment_date
         ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+    </select>
+
+    <!--  출하지시서 현황 월합계 조회  -->
+    <select id="selectMonthlyTotal"
+            resultType="error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionSituationMonthlyTotalDTO">
+        SELECT
+            DATE_FORMAT(si.shipping_instruction_scheduled_shipment_date, '%Y-%m') AS month,
+            SUM(si.shipping_instruction_total_quantity) AS monthly_total
+        FROM tb_shipping_instruction si
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE si.shipping_instruction_status NOT IN ('DELETE')
+        OR si.shipping_instruction_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= si.shipping_instruction_scheduled_shipment_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= si.shipping_instruction_scheduled_shipment_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+        GROUP BY DATE_FORMAT(si.shipping_instruction_scheduled_shipment_date, '%Y-%m')
+    </select>
+
+    <!--  출하지시서 현황 총합계 조회  -->
+    <select id="selectTotal" resultType="Integer">
+        SELECT
+            SUM(si.shipping_instruction_total_quantity) AS total_quantity
+        FROM tb_shipping_instruction si
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE si.shipping_instruction_status NOT IN ('DELETE')
+        OR si.shipping_instruction_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= si.shipping_instruction_scheduled_shipment_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= si.shipping_instruction_scheduled_shipment_date
+            ]]></if>
         <if test="request.clientName != '' and request.clientName != null">
             AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
         </if>

--- a/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="error.pirate.backend.shippingSlip.query.mapper.ShippingSlipMapper">
+
+    <!--    출하전표 리스트 조회  -->
+    <select id="selectShippingSlipList"
+            resultType="error.pirate.backend.shippingSlip.query.dto.ShippingSlipListDTO">
+        SELECT
+            s.shipping_slip_seq,
+            s.shipping_slip_name,
+            s.shipping_slip_shipping_date,
+            c.client_name,
+            (
+                SELECT
+                GROUP_CONCAT(i.item_name SEPARATOR ", ")
+                FROM tb_shipping_slip_item ssi
+                JOIN tb_item i ON i.item_seq = ssi.item_seq
+                WHERE s.shipping_slip_seq = ssi.shipping_slip_seq
+            ) AS item_name
+        FROM tb_shipping_slip s
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_status NOT IN ('DELETE')
+        OR s.shipping_slip_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= s.shipping_slip_shipping_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= s.shipping_slip_shipping_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+        ORDER BY s.shipping_slip_reg_date DESC
+        LIMIT #{request.size} OFFSET #{offset}
+    </select>
+
+    <!--    출하전표 리스트 갯수  -->
+    <select id="countShippingSlip" resultType="long">
+        SELECT COUNT(*)
+        FROM tb_shipping_slip s
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_status NOT IN ('DELETE')
+        OR s.shipping_slip_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= s.shipping_slip_shipping_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= s.shipping_slip_shipping_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+    </select>
+
+    <!--    출하전표 상세 조회  -->
+    <select id="selectShippingSlipByShippingSlipSeq"
+            resultType="error.pirate.backend.shippingSlip.query.dto.ShippingSlipDTO">
+        SELECT
+            s.shipping_slip_seq,
+            s.shipping_slip_name,
+            s.shipping_slip_shipping_date,
+            c.client_name,
+            s.shipping_slip_total_quantity,
+            s.shipping_slip_address,
+            u.user_name,
+            s.shipping_slip_note
+        FROM tb_shipping_slip s
+        JOIN tb_user u ON (s.user_seq = u.user_seq)
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_seq = #{shippingSlipSeq}
+    </select>
+
+    <!--    출하전표 상세 품목 조회  -->
+    <select id="selectItemListByShippingSlipSeq"
+            resultType="error.pirate.backend.shippingSlip.query.dto.ShippingSlipItemDTO">
+        SELECT
+            ssi.shipping_slip_item_seq,
+            ssi.item_seq,
+            i.item_image_url,
+            i.item_name,
+            i.item_division,
+            i.item_price,
+            ssi.shipping_slip_item_quantity,
+            ssi.shipping_slip_item_note,
+            (i.item_price * ssi.shipping_slip_item_quantity) AS itemTotalAmount
+        FROM tb_shipping_slip_item ssi
+        JOIN tb_item i ON ssi.item_seq = i.item_seq
+        WHERE ssi.shipping_slip_seq = #{shippingSlipSeq}
+    </select>
+
+    <!--  출하전표 현황 조회  -->
+    <select id="selectShippingSlipSituation"
+            resultType="error.pirate.backend.shippingSlip.query.dto.ShippingSlipSituationDTO">
+        SELECT
+            s.shipping_slip_seq,
+            s.shipping_slip_shipping_date,
+            s.shipping_slip_name,
+            s.shipping_slip_total_quantity,
+            c.client_name,
+            s.shipping_slip_address,
+            s.shipping_slip_note
+        FROM tb_shipping_slip s
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_status NOT IN ('DELETE')
+        OR s.shipping_slip_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= s.shipping_slip_shipping_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= s.shipping_slip_shipping_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+    </select>
+</mapper>

--- a/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
@@ -123,4 +123,49 @@
             AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
         </if>
     </select>
+
+    <!--  출하전표 현황 월합계 조회  -->
+    <select id="selectMonthlyTotal"
+            resultType="error.pirate.backend.shippingSlip.query.dto.ShippingSlipSituationMonthlyTotalDTO">
+        SELECT
+            DATE_FORMAT(s.shipping_slip_shipping_date, '%Y-%m') AS month,
+            SUM(s.shipping_slip_total_quantity) AS monthly_total
+        FROM tb_shipping_slip s
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_status NOT IN ('DELETE')
+        OR s.shipping_slip_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= s.shipping_slip_shipping_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= s.shipping_slip_shipping_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+        GROUP BY DATE_FORMAT(s.shipping_slip_shipping_date, '%Y-%m')
+    </select>
+
+    <!--  출하전표 현황 총합계 조회  -->
+    <select id="selectTotal" resultType="Integer">
+        SELECT
+            SUM(s.shipping_slip_total_quantity) AS total_quantity
+        FROM tb_shipping_slip s
+        JOIN tb_shipping_instruction si ON (s.shipping_instruction_seq = si.shipping_instruction_seq)
+        JOIN tb_sales_order so ON (si.sales_order_seq = so.sales_order_seq)
+        JOIN tb_client c ON (so.client_seq = c.client_seq)
+        WHERE s.shipping_slip_status NOT IN ('DELETE')
+        OR s.shipping_slip_status IS NULL
+        <if test="request.startDate != null"><![CDATA[
+            AND #{request.startDate} <= s.shipping_slip_shipping_date
+             ]]></if>
+        <if test="request.endDate != null"><![CDATA[
+            AND #{request.endDate} >= s.shipping_slip_shipping_date
+            ]]></if>
+        <if test="request.clientName != '' and request.clientName != null">
+            AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
+        </if>
+    </select>
 </mapper>

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationServiceTest.java
@@ -21,7 +21,6 @@ class ShippingInstructionApplicationServiceTest {
 
     @Autowired
     private ShippingInstructionApplicationService shippingInstructionApplicationService;
-    ;
 
     private static Stream<Arguments> createShippingInstructionArguments() {
         return Stream.of(

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationServiceTest.java
@@ -1,0 +1,119 @@
+package error.pirate.backend.shippingSlip.command.application.service;
+
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@SpringBootTest
+class ShippingSlipApplicationServiceTest {
+
+    @Autowired
+    private ShippingSlipApplicationService shippingSlipApplicationService;
+
+    private static Stream<Arguments> createShippingSlipArguments() {
+        return Stream.of(
+                arguments(
+                        new ShippingSlipRequest(
+                                LocalDateTime.of(2024, 12, 15, 12, 0, 0),
+                                10L,
+                                "첫번째 출하전표",
+                                List.of(
+                                        new ShippingSlipItemDTO(1L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemDTO(2L, 500, "출하전표 물품2"),
+                                        new ShippingSlipItemDTO(3L, 5000, "출하전표 물품3")
+                                )
+                        )
+                ),
+                arguments(
+                        new ShippingSlipRequest(
+                                LocalDateTime.of(2024, 12, 12, 10, 0, 0),
+                                20L,
+                                "두번째 출하전표",
+                                List.of(
+                                        new ShippingSlipItemDTO(4L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemDTO(5L, 500, "출하전표 물품2")
+                                )
+                        )
+                )
+        );
+    }
+
+    @DisplayName("출하전표 등록")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("createShippingSlipArguments")
+    void readShippingSlipListTest(
+            ShippingSlipRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipApplicationService.createShippingSlip(request));
+    }
+
+    private static Stream<Arguments> updateShippingSlipArguments() {
+        return Stream.of(
+                arguments(
+                        24L,
+                        new ShippingSlipRequest(
+                                LocalDateTime.of(2024, 12, 12, 10, 0, 0),
+                                20L,
+                                "두번째 출하전표",
+                                List.of(
+                                        new ShippingSlipItemDTO(4L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemDTO(5L, 500, "출하전표 물품2")
+                                )
+                        )
+                ),
+                arguments(
+                        25L,
+                        new ShippingSlipRequest(
+                                LocalDateTime.of(2024, 12, 15, 12, 0, 0),
+                                10L,
+                                "첫번째 출하전표",
+                                List.of(
+                                        new ShippingSlipItemDTO(1L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemDTO(2L, 500, "출하전표 물품2"),
+                                        new ShippingSlipItemDTO(3L, 5000, "출하전표 물품3")
+                                )
+                        )
+                )
+        );
+    }
+
+    @DisplayName("출하전표 수정")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("updateShippingSlipArguments")
+    void updateShippingSlipTest(
+            Long shippingSlipSeq, ShippingSlipRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipApplicationService.updateShippingSlip(
+                        shippingSlipSeq, request));
+    }
+
+    private static Stream<Arguments> deleteShippingSlipArguments() {
+        return Stream.of(
+                arguments(24L),
+                arguments(25L)
+        );
+    }
+
+    @DisplayName("출하전표 삭제")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("deleteShippingSlipArguments")
+    void deleteShippingSlipTest(Long shippingSlipSeq) {
+        assertDoesNotThrow(
+                () -> shippingSlipApplicationService.deleteShippingSlip(shippingSlipSeq)
+        );
+    }
+}

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryServiceTest.java
@@ -1,0 +1,83 @@
+package error.pirate.backend.shippingSlip.query.service;
+
+import error.pirate.backend.shippingSlip.query.dto.ShippingSlipListRequest;
+import error.pirate.backend.shippingSlip.query.dto.ShippingSlipSituationRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@SpringBootTest
+class ShippingSlipQueryServiceTest {
+
+    @Autowired
+    private ShippingSlipQueryService shippingSlipQueryService;
+
+    private static Stream<Arguments> readShippingSlipListArguments() {
+        return Stream.of(
+                arguments(new ShippingSlipListRequest(1, 10, null, null, null)),
+                arguments(new ShippingSlipListRequest(2, 10, null, null, null)),
+                arguments(new ShippingSlipListRequest(1, 10, LocalDate.of(2024, 12, 20), null, null)),
+                arguments(new ShippingSlipListRequest(1, 10, null, LocalDate.of(2024, 12, 25), null)),
+                arguments(new ShippingSlipListRequest(1, 10, LocalDate.of(2024, 12, 20), LocalDate.of(2024, 12, 25), null)),
+                arguments(new ShippingSlipListRequest(1, 10, null, null, "대한항공"))
+        );
+    }
+
+    @DisplayName("출하전표 목록 조회")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingSlipListArguments")
+    void readShippingSlipListTest(
+            ShippingSlipListRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipQueryService.readShippingSlipList(request));
+    }
+
+    private static Stream<Arguments> readShippingSlipArguments() {
+        return Stream.of(
+                arguments(1L),
+                arguments(2L),
+                arguments(3L),
+                arguments(4L),
+                arguments(5L)
+        );
+    }
+
+    @DisplayName("출하전표 상세 조회")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingSlipArguments")
+    void readShippingSlipTest(
+            long shippingSlipSeq
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipQueryService.readShippingSlip(shippingSlipSeq));
+    }
+
+    private static Stream<Arguments> readShippingSlipSituationArguments() {
+        return Stream.of(
+                arguments(new ShippingSlipSituationRequest(LocalDate.of(2024, 12, 20), null, null)),
+                arguments(new ShippingSlipSituationRequest(null, LocalDate.of(2024, 12, 25), null)),
+                arguments(new ShippingSlipSituationRequest(LocalDate.of(2024, 12, 20), LocalDate.of(2024, 12, 25), null)),
+                arguments(new ShippingSlipSituationRequest(null, null, "대한항공"))
+        );
+    }
+
+    @DisplayName("출하전표 현황 조회")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingSlipSituationArguments")
+    void readShippingSlipSituationTest(
+            ShippingSlipSituationRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipQueryService.readShippingSlipSituation(request));
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
feat: 출하전표 조회/등록/수정/삭제

### 📌 관련 이슈
- **해결할 이슈**: Closes #142 

### 변경 사항
- **핵심 변경 내용**: 출하전표 조회/등록/수정/삭제
- **주요 변경 파일 및 모듈**: 출하전표 컨트롤러, 서비스, 레포지토리

### 🔍 상세 설명
- **구현 내용**: 출하전표 조회/등록/수정/삭제에 필요한 클래스들을 추가
- **코드 영향 범위**: ErrorCodeType에 출하전표 예외 추가, 주문서 엔티티에 상태 변경 메소드 추가
- 메소드 명 수정 및 현황 로직 수정

### ✅ 체크리스트
- [ ] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트가 추가되었는지, 기존 테스트가 수정되었는지 여부
- **테스트 환경**: swagger 테스트, 서비스 테스트

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6a9f99fa-b45f-4f67-87b9-6614b9776c5e)
![image](https://github.com/user-attachments/assets/d0d2b87f-7304-4515-b8a0-75b17fd10327)

