### PR TITLE
feat: 출하지시서, 출하전표 엑셀 다운 기능 구현

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/common/ExcelDownLoad.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/common/ExcelDownLoad.java
@@ -35,7 +35,7 @@ public class ExcelDownLoad {
             }
 
             for (int i = 0; i < excel.length; i++) {
-                Row row = sheet.createRow(i);
+                Row row = sheet.createRow(i+1);
 
                 for(int j = 0; j < excel[i].length; j++) {
                     row.createCell(j).setCellValue(excel[i][j]);

--- a/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/service/SalesOrderDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/salesOrder/command/domain/service/SalesOrderDomainService.java
@@ -15,6 +15,12 @@ public class SalesOrderDomainService {
     
     private final SalesOrderRepository salesOrderRepository;
 
+    /* 주문서 시퀀스로 주문서 불러오기 */
+    public SalesOrder findById(long salesOrderSeq) {
+        return salesOrderRepository.findById(salesOrderSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.SALES_ORDER_NOT_FOUND));
+    }
+
     /* 상태를 수정하는 로직 */
     public void updateSalesOrderStatus(SalesOrder salesOrder, String status) {
         /* 수정을 위해 엔터티 정보 변경 */

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
@@ -1,5 +1,6 @@
 package error.pirate.backend.shippingInstruction.query.controller;
 
+import error.pirate.backend.purchaseOrder.query.dto.PurchaseOrderRequest;
 import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionListRequest;
 import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionListResponse;
 import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionResponse;
@@ -10,8 +11,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 @Tag(name = "출하지시서")
 @RestController
@@ -52,5 +60,18 @@ public class ShippingInstructionQueryController {
                 = shippingInstructionQueryService.readShippingInstructionSituation(request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/excelDown")
+    @Operation(summary = "출하지시서 엑셀 다운")
+    public ResponseEntity<byte[]> shippingInstructionExcelDown(ShippingInstructionListRequest shippingInstructionListRequest) {
+        HttpHeaders headersResponse = new HttpHeaders();
+        String fileName = URLEncoder.encode("출하지시서[" + new SimpleDateFormat("yyyyMMdd").format(new Date()) + "].xlsx", StandardCharsets.UTF_8);
+        headersResponse.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
+
+        return ResponseEntity.ok()
+                .headers(headersResponse)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(shippingInstructionQueryService.shippingInstructionExcelDown(shippingInstructionListRequest));
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionListDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionListDTO.java
@@ -1,10 +1,9 @@
 package error.pirate.backend.shippingInstruction.query.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Data;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Schema(description = "출하지시서 리스트 DTO")
@@ -12,7 +11,7 @@ public class ShippingInstructionListDTO {
     private long shippingInstructionSeq;    // 출하지시서 번호
     private String shippingInstructionName; // 출하지시서명
     private String shippingInstructionStatus;   // 출하지시서 상태
-    private LocalDate shippingInstructionScheduledShipmentDate; // 출하예정일
+    private LocalDateTime shippingInstructionScheduledShipmentDate; // 출하예정일
     private String clientName;  // 거래처명
     private String itemName;    // 품목명
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionListRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionListRequest.java
@@ -11,8 +11,8 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Schema(description = "출하지시서 리스트 요청")
 public class ShippingInstructionListRequest {
-    private int page = 1; // 기본값 설정
-    private int size = 10; // 기본값 설정
+    private Integer page = 1; // 기본값 설정
+    private Integer size = 10; // 기본값 설정
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) // LocalDate 매핑을 위해 필요
     private LocalDate startDate;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
@@ -1,18 +1,23 @@
 package error.pirate.backend.shippingInstruction.query.service;
 
+import error.pirate.backend.common.ExcelDownLoad;
+import error.pirate.backend.purchaseOrder.query.dto.PurchaseOrderResponse;
 import error.pirate.backend.shippingInstruction.query.dto.*;
 import error.pirate.backend.shippingInstruction.query.mapper.ShippingInstructionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ShippingInstructionQueryService {
 
     private final ShippingInstructionMapper shippingInstructionMapper;
+    private final ExcelDownLoad excelDownBody;
 
     /* 출하지시서 리스트 조회 */
     @Transactional(readOnly = true)
@@ -67,5 +72,30 @@ public class ShippingInstructionQueryService {
                 .monthlyTotalList(monthlyTotalList)
                 .totalQuantity(totalQuantity)
                 .build();
+    }
+
+    /* 출하지시서 엑셀 다운 */
+    public byte[] shippingInstructionExcelDown(ShippingInstructionListRequest request) {
+        int offset = (request.getPage() - 1) * request.getSize();
+        request.setSize(null);
+        List<ShippingInstructionListDTO> shippingInstructionList
+                = shippingInstructionMapper.selectShippingInstructionList(offset, request);
+
+        String[] headers = {"출하지시서명", "출하지시서 품목", "거래처명", "출하예정일", "상태"};
+        String[][] excel = new String[shippingInstructionList.size()][headers.length];
+
+        for(int i=0 ; i<shippingInstructionList.size() ; i++) {
+            ShippingInstructionListDTO dto = shippingInstructionList.get(i);
+
+            excel[i][0] = dto.getShippingInstructionName();
+            excel[i][1] = dto.getItemName();//  품목
+            excel[i][2] = dto.getClientName();
+            excel[i][3] = dto.getShippingInstructionScheduledShipmentDate() != null
+                    ? dto.getShippingInstructionScheduledShipmentDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                    : null;
+            excel[i][4] = String.valueOf(dto.getShippingInstructionStatus());
+        }
+
+        return excelDownBody.excelDownBody(excel, headers, "출하지시서");
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/controller/ShippingSlipQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/controller/ShippingSlipQueryController.java
@@ -1,13 +1,21 @@
 package error.pirate.backend.shippingSlip.query.controller;
 
+import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionListRequest;
 import error.pirate.backend.shippingSlip.query.dto.*;
 import error.pirate.backend.shippingSlip.query.service.ShippingSlipQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 @Tag(name = "출하전표")
 @RestController
@@ -48,5 +56,18 @@ public class ShippingSlipQueryController {
                 = shippingSlipQueryService.readShippingSlipSituation(request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/excelDown")
+    @Operation(summary = "출하전표 엑셀 다운")
+    public ResponseEntity<byte[]> shippingInstructionExcelDown(ShippingSlipListRequest request) {
+        HttpHeaders headersResponse = new HttpHeaders();
+        String fileName = URLEncoder.encode("출하전표[" + new SimpleDateFormat("yyyyMMdd").format(new Date()) + "].xlsx", StandardCharsets.UTF_8);
+        headersResponse.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
+
+        return ResponseEntity.ok()
+                .headers(headersResponse)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(shippingSlipQueryService.shippingSlipExcelDown(request));
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListDTO.java
@@ -3,14 +3,14 @@ package error.pirate.backend.shippingSlip.query.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Schema(description = "출하전표 리스트 DTO")
 public class ShippingSlipListDTO {
     private long shippingSlipSeq;    // 출하전표 번호
     private String shippingSlipName; // 출하전표명
-    private LocalDate shippingSlipShippingDate; // 출하일
+    private LocalDateTime shippingSlipShippingDate; // 출하일
     private String clientName;  // 거래처명
     private String itemName;    // 품목명
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/dto/ShippingSlipListRequest.java
@@ -11,8 +11,8 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Schema(description = "출하전표 리스트 요청")
 public class ShippingSlipListRequest {
-    private int page = 1; // 기본값 설정
-    private int size = 10; // 기본값 설정
+    private Integer page = 1; // 기본값 설정
+    private Integer size = 10; // 기본값 설정
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) // LocalDate 매핑을 위해 필요
     private LocalDate startDate;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryService.java
@@ -72,6 +72,7 @@ public class ShippingSlipQueryService {
                 .build();
     }
 
+    /* 출하전표 엑셀 다운 */
     public byte[] shippingSlipExcelDown(ShippingSlipListRequest request) {
         int offset = (request.getPage() - 1) * request.getSize();
         request.setSize(null);

--- a/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
@@ -37,7 +37,9 @@
             AND si.shipping_instruction_status LIKE #{request.shippingInstructionStatus}
         </if>
         ORDER BY si.shipping_instruction_reg_date DESC
-        LIMIT #{request.size} OFFSET #{offset}
+        <if test="request.size != null">
+            LIMIT #{request.size} OFFSET #{offset}
+        </if>
     </select>
 
     <!--    출하지시서 리스트 갯수  -->

--- a/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingSlip/ShippingSlipMapper.xml
@@ -34,7 +34,9 @@
             AND c.client_name LIKE CONCAT('%', #{request.clientName}, '%')
         </if>
         ORDER BY s.shipping_slip_reg_date DESC
-        LIMIT #{request.size} OFFSET #{offset}
+        <if test="request.size != null">
+            LIMIT #{request.size} OFFSET #{offset}
+        </if>
     </select>
 
     <!--    출하전표 리스트 갯수  -->

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryServiceTest.java
@@ -44,6 +44,16 @@ class ShippingInstructionQueryServiceTest {
                 () -> shippingInstructionQueryService.readShippingInstructionList(request));
     }
 
+    @DisplayName("출하지시서 엑셀 다운")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingInstructionListArguments")
+    void shippingInstructionExcelDownTest(
+            ShippingInstructionListRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingInstructionQueryService.shippingInstructionExcelDown(request));
+    }
+
     private static Stream<Arguments> readShippingInstructionArguments() {
         return Stream.of(
                 arguments(1L),

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/query/service/ShippingSlipQueryServiceTest.java
@@ -42,6 +42,16 @@ class ShippingSlipQueryServiceTest {
                 () -> shippingSlipQueryService.readShippingSlipList(request));
     }
 
+    @DisplayName("출하전표 엑셀 다운")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingSlipListArguments")
+    void shippingSlipExcelDownTest(
+            ShippingSlipListRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingSlipQueryService.shippingSlipExcelDown(request));
+    }
+
     private static Stream<Arguments> readShippingSlipArguments() {
         return Stream.of(
                 arguments(1L),


### PR DESCRIPTION
## 📝 PR 설명
 출하지시서, 출하전표 엑셀 다운 기능 구현

### 📌 관련 이슈
- **해결할 이슈**: Closes #186 

### 변경 사항
- **핵심 변경 내용**:  출하지시서, 출하전표 엑셀 다운 기능 구현 및 서비스 테스트 작성
- **주요 변경 파일 및 모듈**: ExcelDownload 일부 수정, SalesOrder 서비스 에러 수정
- 엑셀 다운 관련 서비스와 컨트롤러 추가
- 이 과정에서 올바르지 않는 response 타입과 DTO 타입 수정

### 🔍 상세 설명
- **구현 내용**: 출하지시서, 출하전표 엑셀 다운 기능 구현 및 서비스 테스트 작성
- **코드 영향 범위**: ExcelDownload , SalesOrder 변경 유의

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [x] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트가 추가
- **테스트 환경**: swagger 테스트, 서비스 테스트

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/0527b90f-a426-46f8-a5bd-ab4fc3c24f93)
![image](https://github.com/user-attachments/assets/82f94ed5-7ca7-47a8-954f-a6656a78fcd2)
![image](https://github.com/user-attachments/assets/1ed564db-b9f5-44ba-b841-2454214ca8b8)

