### PR TITLE
refactor: 프론트엔드 출하지시서 조회, 등록 리팩토링 및 백엔드 클래스명 수정

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/dto/ShippingInstructionItemRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/dto/ShippingInstructionItemRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Schema(description = "출하지시서 품목 DTO")
-public class ShippingInstructionItemDTO {
+public class ShippingInstructionItemRequest {
     private long itemSeq;    // 품목 시퀀스
     private int shippingInstructionItemQuantity;    // 물품 수량
     private String shippingInstructionItemNote;     // 물품 비고

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/dto/ShippingInstructionRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/dto/ShippingInstructionRequest.java
@@ -3,7 +3,6 @@ package error.pirate.backend.shippingInstruction.command.application.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,5 +15,5 @@ public class ShippingInstructionRequest {
     private long salesOrderSeq;  // 주문서 시퀀스
     private String shippingInstructionAddress;  // 출하 주소
     private String shippingInstructionNote; // 출하 지시서 비고
-    private List<ShippingInstructionItemDTO> shippingInstructionItems; // 물품 리스트
+    private List<ShippingInstructionItemRequest> shippingInstructionItems; // 물품 리스트
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationService.java
@@ -4,7 +4,7 @@ import error.pirate.backend.common.NameGenerator;
 import error.pirate.backend.item.command.application.service.ItemService;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
 import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
-import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemDTO;
+import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemRequest;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionItem;
@@ -67,7 +67,7 @@ public class ShippingInstructionApplicationService {
         /* 물품 불러오기 */
         List<Long> itemSeqList = shippingInstructionRequest.getShippingInstructionItems()
                 .stream()
-                .map(ShippingInstructionItemDTO::getItemSeq) // itemSeq 필드 추출
+                .map(ShippingInstructionItemRequest::getItemSeq) // itemSeq 필드 추출
                 .toList(); // 추출한 값을 List로 변환
         List<Item> itemList = itemService.findAllById(itemSeqList);
 
@@ -125,7 +125,7 @@ public class ShippingInstructionApplicationService {
             /* 물품 불러오기 */
             List<Long> itemSeqList = shippingInstructionRequest.getShippingInstructionItems()
                     .stream()
-                    .map(ShippingInstructionItemDTO::getItemSeq) // itemSeq 필드 추출
+                    .map(ShippingInstructionItemRequest::getItemSeq) // itemSeq 필드 추출
                     .toList(); // 추출한 값을 List로 변환
             List<Item> itemList = itemService.findAllById(itemSeqList);
 

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionDomainService.java
@@ -4,7 +4,7 @@ import error.pirate.backend.exception.CustomException;
 import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
 import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrderStatus;
-import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemDTO;
+import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemRequest;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionStatus;
@@ -93,7 +93,7 @@ public class ShippingInstructionDomainService {
         // stream을 사용해 shippingInstructionItemQuantity 필드 합산
         return request.getShippingInstructionItems()
                 .stream()
-                .mapToInt(ShippingInstructionItemDTO::getShippingInstructionItemQuantity)
+                .mapToInt(ShippingInstructionItemRequest::getShippingInstructionItemQuantity)
                 .sum();
     }
 

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/mapper/ShippingInstructionItemMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/mapper/ShippingInstructionItemMapper.java
@@ -3,7 +3,7 @@ package error.pirate.backend.shippingInstruction.command.mapper;
 import error.pirate.backend.exception.CustomException;
 import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
-import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemDTO;
+import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemRequest;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionItem;
@@ -22,14 +22,14 @@ public class ShippingInstructionItemMapper {
         List<ShippingInstructionItem> shippingInstructionItemList = new ArrayList<>();
 
         // shippingInstructionRequest에서 shippingInstructionItems 가져오기
-        List<ShippingInstructionItemDTO> itemDTOList  = shippingInstructionRequest.getShippingInstructionItems();
+        List<ShippingInstructionItemRequest> itemDTOList  = shippingInstructionRequest.getShippingInstructionItems();
 
         // itemList를 Map으로 변환하여 매핑 속도 향상
         Map<Long, Item> itemMap = itemList.stream()
                 .collect(Collectors.toMap(Item::getItemSeq, item -> item));
 
         // DTO 리스트를 순회하며 ShippingInstructionItem 생성
-        for (ShippingInstructionItemDTO itemDTO : itemDTOList) {
+        for (ShippingInstructionItemRequest itemDTO : itemDTOList) {
             Item item = itemMap.get(itemDTO.getItemSeq()); // itemSeq으로 Item 매핑
 
             if (item == null) {

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipItemRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipItemRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Schema(description = "출하전표 품목 DTO")
-public class ShippingSlipItemDTO {
+public class ShippingSlipItemRequest {
     private long itemSeq;    // 품목 시퀀스
     private int shippingSlipItemQuantity;    // 물품 수량
     private String shippingSlipItemNote;     // 물품 비고

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipRequest.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/dto/ShippingSlipRequest.java
@@ -14,5 +14,5 @@ public class ShippingSlipRequest {
     private LocalDateTime shippingSlipShippingDate; // 출하일
     private long shippingInstructionSeq;  // 출하지시서 시퀀스
     private String shippingSlipNote; // 출하전표 비고
-    private List<ShippingSlipItemDTO> shippingSlipItems; // 물품 리스트
+    private List<ShippingSlipItemRequest> shippingSlipItems; // 물품 리스트
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationService.java
@@ -5,7 +5,7 @@ import error.pirate.backend.item.command.application.service.ItemService;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
 import error.pirate.backend.salesOrder.command.domain.service.SalesOrderDomainService;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
-import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemRequest;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
@@ -70,7 +70,7 @@ public class ShippingSlipApplicationService {
         /* 물품 불러오기 */
         List<Long> itemSeqList = shippingSlipRequest.getShippingSlipItems()
                 .stream()
-                .map(ShippingSlipItemDTO::getItemSeq) // itemSeq 필드 추출
+                .map(ShippingSlipItemRequest::getItemSeq) // itemSeq 필드 추출
                 .toList(); // 추출한 값을 List로 변환
         List<Item> itemList = itemService.findAllById(itemSeqList);
 
@@ -134,7 +134,7 @@ public class ShippingSlipApplicationService {
             /* 물품 불러오기 */
             List<Long> itemSeqList = shippingSlipRequest.getShippingSlipItems()
                     .stream()
-                    .map(ShippingSlipItemDTO::getItemSeq) // itemSeq 필드 추출
+                    .map(ShippingSlipItemRequest::getItemSeq) // itemSeq 필드 추출
                     .toList(); // 추출한 값을 List로 변환
             List<Item> itemList = itemService.findAllById(itemSeqList);
 

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/domain/service/ShippingSlipDomainService.java
@@ -4,7 +4,7 @@ import error.pirate.backend.exception.CustomException;
 import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionStatus;
-import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemRequest;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipStatus;
@@ -94,7 +94,7 @@ public class ShippingSlipDomainService {
         // stream을 사용해 shippingSlipItemQuantity 필드 합산
         return request.getShippingSlipItems()
                 .stream()
-                .mapToInt(ShippingSlipItemDTO::getShippingSlipItemQuantity)
+                .mapToInt(ShippingSlipItemRequest::getShippingSlipItemQuantity)
                 .sum();
     }
 

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipItemMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingSlip/command/mapper/ShippingSlipItemMapper.java
@@ -3,7 +3,7 @@ package error.pirate.backend.shippingSlip.command.mapper;
 import error.pirate.backend.exception.CustomException;
 import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
-import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemRequest;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlip;
 import error.pirate.backend.shippingSlip.command.domain.aggregate.entity.ShippingSlipItem;
@@ -22,14 +22,14 @@ public class ShippingSlipItemMapper {
         List<ShippingSlipItem> shippingSlipItemList = new ArrayList<>();
 
         // shippingSlipRequest에서 shippingSlipItems 가져오기
-        List<ShippingSlipItemDTO> itemDTOList  = shippingSlipRequest.getShippingSlipItems();
+        List<ShippingSlipItemRequest> itemDTOList  = shippingSlipRequest.getShippingSlipItems();
 
         // itemList를 Map으로 변환하여 매핑 속도 향상
         Map<Long, Item> itemMap = itemList.stream()
                 .collect(Collectors.toMap(Item::getItemSeq, item -> item));
 
         // DTO 리스트를 순회하며 ShippingInstructionItem 생성
-        for (ShippingSlipItemDTO itemDTO : itemDTOList) {
+        for (ShippingSlipItemRequest itemDTO : itemDTOList) {
             Item item = itemMap.get(itemDTO.getItemSeq()); // itemSeq으로 Item 매핑
 
             if (item == null) {

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/command/application/service/ShippingInstructionApplicationServiceTest.java
@@ -1,6 +1,6 @@
 package error.pirate.backend.shippingInstruction.command.application.service;
 
-import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemDTO;
+import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemRequest;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,9 +31,9 @@ class ShippingInstructionApplicationServiceTest {
                                 "인천시",
                                 "첫번째 출하지시서",
                                 List.of(
-                                        new ShippingInstructionItemDTO(1L, 100, "출하지시서 물품1"),
-                                        new ShippingInstructionItemDTO(2L, 500, "출하지시서 물품2"),
-                                        new ShippingInstructionItemDTO(3L, 5000, "출하지시서 물품3")
+                                        new ShippingInstructionItemRequest(1L, 100, "출하지시서 물품1"),
+                                        new ShippingInstructionItemRequest(2L, 500, "출하지시서 물품2"),
+                                        new ShippingInstructionItemRequest(3L, 5000, "출하지시서 물품3")
                                 )
                         )
                 ),
@@ -44,8 +44,8 @@ class ShippingInstructionApplicationServiceTest {
                                 "부산시",
                                 "두번째 출하지시서",
                                 List.of(
-                                        new ShippingInstructionItemDTO(4L, 100, "출하지시서 물품1"),
-                                        new ShippingInstructionItemDTO(5L, 500, "출하지시서 물품2")
+                                        new ShippingInstructionItemRequest(4L, 100, "출하지시서 물품1"),
+                                        new ShippingInstructionItemRequest(5L, 500, "출하지시서 물품2")
                                 )
                         )
                 )
@@ -72,8 +72,8 @@ class ShippingInstructionApplicationServiceTest {
                                 "부산시",
                                 "두번째 출하지시서",
                                 List.of(
-                                        new ShippingInstructionItemDTO(4L, 100, "출하지시서 물품1"),
-                                        new ShippingInstructionItemDTO(5L, 500, "출하지시서 물품2")
+                                        new ShippingInstructionItemRequest(4L, 100, "출하지시서 물품1"),
+                                        new ShippingInstructionItemRequest(5L, 500, "출하지시서 물품2")
                                 )
                         )
                 ),
@@ -85,9 +85,9 @@ class ShippingInstructionApplicationServiceTest {
                                 "인천시",
                                 "첫번째 출하지시서",
                                 List.of(
-                                        new ShippingInstructionItemDTO(1L, 100, "출하지시서 물품1"),
-                                        new ShippingInstructionItemDTO(2L, 500, "출하지시서 물품2"),
-                                        new ShippingInstructionItemDTO(3L, 5000, "출하지시서 물품3")
+                                        new ShippingInstructionItemRequest(1L, 100, "출하지시서 물품1"),
+                                        new ShippingInstructionItemRequest(2L, 500, "출하지시서 물품2"),
+                                        new ShippingInstructionItemRequest(3L, 5000, "출하지시서 물품3")
                                 )
                         )
                 )

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryServiceTest.java
@@ -2,6 +2,7 @@ package error.pirate.backend.shippingInstruction.query.service;
 
 import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionListRequest;
 import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionSituationRequest;
+import error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,8 +31,9 @@ class ShippingInstructionQueryServiceTest {
                 arguments(new ShippingInstructionListRequest(1, 10, null, LocalDate.of(2024, 12, 25), null, null)),
                 arguments(new ShippingInstructionListRequest(1, 10, LocalDate.of(2024, 12, 20), LocalDate.of(2024, 12, 25), null, null)),
                 arguments(new ShippingInstructionListRequest(1, 10, null, null, "대한항공", null)),
-                arguments(new ShippingInstructionListRequest(1, 10, null, null, null, "BEFORE")),
-                arguments(new ShippingInstructionListRequest(1, 10, null, null, null, "AFTER"))
+                arguments(new ShippingInstructionListRequest(1, 10, null, null, null, List.of(ShippingInstructionStatus.BEFORE))),
+                arguments(new ShippingInstructionListRequest(1, 10, null, null, null, List.of(ShippingInstructionStatus.AFTER))),
+                arguments(new ShippingInstructionListRequest(1, 10, null, null, null, List.of(ShippingInstructionStatus.BEFORE, ShippingInstructionStatus.AFTER)))
         );
     }
 
@@ -91,5 +94,15 @@ class ShippingInstructionQueryServiceTest {
     ) {
         assertDoesNotThrow(
                 () -> shippingInstructionQueryService.readShippingInstructionSituation(request));
+    }
+
+    @DisplayName("출하지시서 현황 엑셀 다운")
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("readShippingInstructionSituationArguments")
+    void shippingInstructionSituationExcelDownTest(
+            ShippingInstructionSituationRequest request
+    ) {
+        assertDoesNotThrow(
+                () -> shippingInstructionQueryService.shippingInstructionSituationExcelDown(request));
     }
 }

--- a/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationServiceTest.java
+++ b/SCM/backend/src/test/java/error/pirate/backend/shippingSlip/command/application/service/ShippingSlipApplicationServiceTest.java
@@ -1,6 +1,6 @@
 package error.pirate.backend.shippingSlip.command.application.service;
 
-import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemDTO;
+import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipItemRequest;
 import error.pirate.backend.shippingSlip.command.application.dto.ShippingSlipRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,9 +30,9 @@ class ShippingSlipApplicationServiceTest {
                                 10L,
                                 "첫번째 출하전표",
                                 List.of(
-                                        new ShippingSlipItemDTO(1L, 100, "출하전표 물품1"),
-                                        new ShippingSlipItemDTO(2L, 500, "출하전표 물품2"),
-                                        new ShippingSlipItemDTO(3L, 5000, "출하전표 물품3")
+                                        new ShippingSlipItemRequest(1L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemRequest(2L, 500, "출하전표 물품2"),
+                                        new ShippingSlipItemRequest(3L, 5000, "출하전표 물품3")
                                 )
                         )
                 ),
@@ -42,8 +42,8 @@ class ShippingSlipApplicationServiceTest {
                                 20L,
                                 "두번째 출하전표",
                                 List.of(
-                                        new ShippingSlipItemDTO(4L, 100, "출하전표 물품1"),
-                                        new ShippingSlipItemDTO(5L, 500, "출하전표 물품2")
+                                        new ShippingSlipItemRequest(4L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemRequest(5L, 500, "출하전표 물품2")
                                 )
                         )
                 )
@@ -69,8 +69,8 @@ class ShippingSlipApplicationServiceTest {
                                 20L,
                                 "두번째 출하전표",
                                 List.of(
-                                        new ShippingSlipItemDTO(4L, 100, "출하전표 물품1"),
-                                        new ShippingSlipItemDTO(5L, 500, "출하전표 물품2")
+                                        new ShippingSlipItemRequest(4L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemRequest(5L, 500, "출하전표 물품2")
                                 )
                         )
                 ),
@@ -81,9 +81,9 @@ class ShippingSlipApplicationServiceTest {
                                 10L,
                                 "첫번째 출하전표",
                                 List.of(
-                                        new ShippingSlipItemDTO(1L, 100, "출하전표 물품1"),
-                                        new ShippingSlipItemDTO(2L, 500, "출하전표 물품2"),
-                                        new ShippingSlipItemDTO(3L, 5000, "출하전표 물품3")
+                                        new ShippingSlipItemRequest(1L, 100, "출하전표 물품1"),
+                                        new ShippingSlipItemRequest(2L, 500, "출하전표 물품2"),
+                                        new ShippingSlipItemRequest(3L, 5000, "출하전표 물품3")
                                 )
                         )
                 )

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputForm.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputForm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {defineProps, ref, watch} from "vue";
 import searchIcon from '@/assets/searchIcon.svg'
+import dayjs from "dayjs";
 
 const props = defineProps({
   salesOrderList: {type: Array, required: true},       // 출하지시서 목록
@@ -38,18 +39,6 @@ const getData  = () => {
   return formData;
 };
 defineExpose({ getData });
-
-// 날짜 포맷 함수
-const formatDate = (dateString) => {
-  if (!dateString) return '';
-
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-
-  return `${year}/${month}/${day}`;
-};
 
 // 상태 포맷 함수
 const formatStatus = (status) => {
@@ -151,7 +140,7 @@ const formatStatus = (status) => {
                 </div>
                 <div class="list-body col-2">{{ salesOrder.clientName }}</div>
                 <div class="list-body col-2">{{
-                    formatDate(salesOrder.salesOrderOrderDate)
+                    dayjs(salesOrder.salesOrderOrderDate).format('YYYY/MM/DD')
                   }}
                 </div>
                 <div class="list-body col-2">{{ formatStatus(salesOrder.salesOrderStatus) }}</div>

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputForm.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputForm.vue
@@ -112,7 +112,7 @@ const formatStatus = (status) => {
 
   <!-- client Modal bootstrap -->
   <div class="modal fade" id="ClientModal" tabindex="-1" aria-labelledby="ClientModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-xl">
+    <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="modal-header">
           <h1 class="modal-title fs-5" id="exampleModalLabel">물품 선택</h1>
@@ -120,30 +120,30 @@ const formatStatus = (status) => {
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <div style="max-height: 500px; overflow-y: scroll"
+          <div style="max-height: 500px; overflow-y: auto"
                class="d-flex row justify-content-center align-items-center">
             <div class="list-headline row">
-              <div class="list-head col-6">주문서</div>
-              <div class="list-head col-2">거래처</div>
-              <div class="list-head col-2">주문일</div>
-              <div class="list-head col-2">상태</div>
+              <div class="list-head col-md-6">주문서</div>
+              <div class="list-head col-md-2">거래처</div>
+              <div class="list-head col-md-2">주문일</div>
+              <div class="list-head col-md-2">상태</div>
             </div>
             <template v-if="salesOrderList.length > 0">
               <div v-for="(salesOrder, index) in salesOrderList"
                    :key="salesOrder.salesOrderSeq"
                    class="list-line row" data-bs-dismiss="modal" @click="addClient(index)">
-                <div class="list-body col-6 left">
+                <div class="list-body col-md-6 left">
                   {{ salesOrder.salesOrderName }}
                   <br>
                   <div v-if="!salesOrder.itemName"><br></div>
                   <div v-else>{{ salesOrder.itemName }}</div>
                 </div>
-                <div class="list-body col-2">{{ salesOrder.clientName }}</div>
-                <div class="list-body col-2">{{
+                <div class="list-body col-md-2">{{ salesOrder.clientName }}</div>
+                <div class="list-body col-md-2">{{
                     dayjs(salesOrder.salesOrderOrderDate).format('YYYY/MM/DD')
                   }}
                 </div>
-                <div class="list-body col-2">{{ formatStatus(salesOrder.salesOrderStatus) }}</div>
+                <div class="list-body col-md-2">{{ formatStatus(salesOrder.salesOrderStatus) }}</div>
               </div>
             </template>
             <template v-else>
@@ -176,8 +176,9 @@ div {
 .list-headline {
   width: 90%;
   border-bottom: 1px solid black;
+  margin-left: 1px;
   margin-bottom: 10px;
-  padding: 20px 40px 20px 20px;
+  padding: 10px 5px 10px 5px;
 }
 
 .list-head {
@@ -190,7 +191,7 @@ div {
   border-radius: 8px;
   margin-left: 1px;
   margin-top: 20px;
-  padding: 20px 40px 20px 20px;
+  padding: 10px 5px 10px 5px;
 }
 
 .list-body {
@@ -201,5 +202,9 @@ div {
 .pagination {
   justify-content: center; /* 가로 중앙 정렬 */
   margin-top: 20px;
+}
+
+.left {
+  text-align: left;
 }
 </style>

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
@@ -1,12 +1,13 @@
 <script setup>
 import {defineProps, ref, watch} from "vue";
+import trashIcon from '@/assets/trashIcon.svg'
 
 const props = defineProps({
   itemList: {type: Array, required: true},       // 주문서 품목 리스트
   selectedSalesOrder: {type: Boolean },       // 주문서 선택 여부
 });
 
-const emit = defineEmits(['registerEvent']);
+const emit = defineEmits(['registerEvent', 'updateItemListEvent']);
 
 // itemList의 각 아이템에 대해 itemData 초기화
 const itemData = ref(props.itemList.map(item => ({
@@ -27,6 +28,23 @@ watch(() => props.itemList, (newItemList) => {
   }));
 });
 
+// 특정 아이템 삭제
+const deleteItem = (index) => {
+  // 아이템이 하나만 남아 있으면 삭제 불가능
+  if (itemData.value.length <= 1) {
+    alert("최소 하나의 품목은 등록해야 합니다."); // 사용자 알림
+    return;
+  }
+
+  // itemData에서 해당 index 삭제
+  itemData.value.splice(index, 1);
+
+  // props.itemList를 업데이트하기 위해 부모 컴포넌트로 emit
+  const updatedItemList = [...props.itemList];
+  updatedItemList.splice(index, 1);
+  emit('updateItemListEvent', updatedItemList); // 부모 컴포넌트에서 itemList 갱신
+};
+
 // // 가격과 수량을 변경할 때마다 총금액 계산하기 위한 watch
 // watch(itemData, (newItemData) => {
 //   newItemData.forEach((data, index) => {
@@ -42,7 +60,7 @@ const addShippingInstruction = () => {
 // 품목 포맷 함수
 const formatDivision = (divisionString) => {
   if (divisionString === 'FINISHED') {
-    return '생산완료';
+    return '완제품';
   }else if(divisionString === 'RAW'){
     return '구성품';
   }else if(divisionString === 'PART'){
@@ -65,6 +83,7 @@ const formatDivision = (divisionString) => {
           <div class="p-2 col-md-8">
             <div class="mb-4 d-flex justify-content-between">
               <span class="fw-bold">{{ item.itemName }}</span>
+              <trashIcon class="icon" @click="deleteItem(index)"/>
             </div>
             <div class="d-flex">
               <ul class="col-md-4">
@@ -102,5 +121,10 @@ li {
 .button {
   background-color: #FFF8E7;
   border: 1px solid;
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
 }
 </style>

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
@@ -69,7 +69,7 @@ const formatDivision = (divisionString) => {
             <div class="d-flex">
               <ul class="col-md-4">
                 <li class="mb-3">
-                  · 품목 : {{ formatDivision(item.itemDivision) }}
+                  · 품목 구분 : {{ formatDivision(item.itemDivision) }}
                 </li>
                 <li class="mb-3 d-flex flex-row">
                   · 수량 :
@@ -88,8 +88,7 @@ const formatDivision = (divisionString) => {
         </div>
       </div>
       <div class="mx-5 my-3 d-flex justify-content-end">
-        <b-button class="mx-3" pill variant="primary" @click="addShippingInstruction">확인</b-button>
-        <b-button class="mx-3" pill>목록</b-button>
+        <b-button class="button mx-3" variant="light" size="sm" @click="addShippingInstruction">확인</b-button>
       </div>
     </div>
   </template>
@@ -98,5 +97,10 @@ const formatDivision = (divisionString) => {
 <style scoped>
 li {
   list-style: none;
+}
+
+.button {
+  background-color: #FFF8E7;
+  border: 1px solid;
 }
 </style>

--- a/SCM/frontend/src/views/shippingInstruction/ShippingInstructionInputView.vue
+++ b/SCM/frontend/src/views/shippingInstruction/ShippingInstructionInputView.vue
@@ -153,6 +153,9 @@ const handleRegister = async (itemList) => {
 
 <template>
   <h4 class="title">영업관리 > 출하지시서 등록</h4>
+  <div class="d-flex justify-content-end mt-3">
+    <b-button @click="router.push('/shipping-instruction')" variant="light" size="sm" class="button ms-2">목록</b-button>
+  </div>
   <div class="d-flex justify-content-center">
     <ShippingInstructionInputForm ref="childRef"
                                   :salesOrderList="salesOrderList"
@@ -176,5 +179,10 @@ const handleRegister = async (itemList) => {
 <style scoped>
 .title {
   padding-bottom: 20px;
+}
+
+.button {
+  background-color: #FFF8E7;
+  border: 1px solid;
 }
 </style>

--- a/SCM/frontend/src/views/shippingInstruction/ShippingInstructionInputView.vue
+++ b/SCM/frontend/src/views/shippingInstruction/ShippingInstructionInputView.vue
@@ -108,6 +108,11 @@ const handleSalesOrder = (formData) => {
   selectedSalesOrder.value = true;
 }
 
+// 품목 리스트 갱신
+const handleUpdateItemList = (updatedList) => {
+  itemList.value = updatedList; // 자식에서 전달된 새 itemList로 갱신
+};
+
 // 등록 핸들러
 const handleRegister = async (itemList) => {
   if (childRef.value) {
@@ -138,7 +143,7 @@ const handleRegister = async (itemList) => {
     });
 
     if (invalidItem) {
-      alert(`품목 수량을 확인해 주세요.`);
+      alert(`품목 수량을 확인해 주세요. 0이하거나 원래 수량보다 많습니다.`);
       return;
     }
 
@@ -172,7 +177,8 @@ const handleRegister = async (itemList) => {
   <div class="d-flex justify-content-center">
     <ShippingInstructionInputItems :itemList="itemList"
                                    :selectedSalesOrder="selectedSalesOrder"
-                                   @registerEvent="handleRegister"/>
+                                   @registerEvent="handleRegister"
+                                   @updateItemListEvent="handleUpdateItemList"/>
   </div>
 </template>
 

--- a/SCM/frontend/src/views/shippingInstruction/ShippingInstructionListView.vue
+++ b/SCM/frontend/src/views/shippingInstruction/ShippingInstructionListView.vue
@@ -50,8 +50,6 @@ const fetchShippingInstruction = async (seq) => {
 
     expandShippingInstruction.value[seq] = response.data.shippingInstructionDTO; // ref 값에 추가
     expandItemList.value[seq] = response.data.itemList;
-    console.log('상세 데이터:', expandShippingInstruction.value);
-    console.log('품목 데이터:', expandItemList.value);
 
   } catch (error) {
     console.error("상세 출하지시서 불러오기 실패 :", error);
@@ -63,7 +61,6 @@ const deleteShippingInstruction = async (seq) => {
   try {
     const response = await axios.delete(`http://localhost:8090/api/v1/shipping-instruction/${seq}`, {});
 
-    console.log(response);
     alert("출하지시서가 삭제되었습니다.");
 
   } catch (error) {

--- a/SCM/frontend/src/views/shippingInstruction/ShippingInstructionListView.vue
+++ b/SCM/frontend/src/views/shippingInstruction/ShippingInstructionListView.vue
@@ -147,11 +147,6 @@ const handleStatus = (payload) => {
   search();
 };
 
-// 등록 페이지 이동
-const handleRegister = () => {
-  router.push("/shipping-instruction/input");
-};
-
 // 삭제 수행
 const handleDelete = async (seq) => {
   if (seq != null) {
@@ -195,7 +190,7 @@ const handleExtendItem = (seq) => {
                            @searchEvent="handleSearch"
                            @checkStatusEvent="handleStatus"
                            @extendItemEvent="handleExtendItem"
-                           @registerEvent="handleRegister"
+                           @registerEvent="router.push('/shipping-instruction/input')"
                            @itemDeleteEvent="handleDelete"
                            @excelEvent="excelDown"
   />


### PR DESCRIPTION
## 📝 PR 설명
프론트엔드 출하지시서 조회, 등록 리팩토링 및 백엔드 클래스명 수정
출하지시서 등록 페이지 품목 지우고 업데이트
백엔드 쪽은 클래스명만 바꼈습니다

### 📌 관련 이슈
- **해결할 이슈**: Closes #217 

### 변경 사항
- **핵심 변경 내용**: 프론트엔드 출하지시서 조회, 등록 리팩토링 및 백엔드 클래스명 수정
- 출하지시서 등록 페이지 품목 지우고 업데이트
- **주요 변경 파일 및 모듈**: view, component, 클래스 이름이 바뀌는 영향들

### 🔍 상세 설명
- **구현 내용**: 프론트엔드 출하지시서 조회, 등록 리팩토링 및 백엔드 클래스명 수정
- 출하지시서 등록 페이지 품목 지우고 업데이트
- **코드 영향 범위**: 없음

### ✅ 체크리스트
- [ ] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트가 추가되었는지, 기존 테스트가 수정되었는지 여부
- **테스트 환경**: vue 테스트

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9ef673ed-7f92-464f-a14d-4fbbdddca2f4)

