### PR TITLE
refactor: 등록 시 불러온 주문서나 출하지시서의 수량 확인 절차 로직

### DIFF
--- a/SCM/backend/src/main/java/error/pirate/backend/common/RemainingQuantity.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/common/RemainingQuantity.java
@@ -1,0 +1,44 @@
+package error.pirate.backend.common;
+
+import error.pirate.backend.common.mapper.CommonMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RemainingQuantity {
+
+    private final CommonMapper commonMapper;
+
+    /**
+     * 남은 품목을 조회할 Entity.class와 등록 할 Entity.class 와 조회할 seq 를 입력하면 남은 품목들을 보여줌<br>
+     * 수량에 해당하는 Integer 리스트 반환 .
+     *
+     * @param selectDomain Entity.class
+     * @param joinDomain Entity.class
+     * @param seq long
+     * @return 남은 수량 리스트
+     */
+    public List<Integer> remainingQuantity(Class selectDomain, Class joinDomain, long seq) {
+        return commonMapper.remainingQuantity(
+                pascalToSnake(selectDomain.getSimpleName()),
+                pascalToSnake(joinDomain.getSimpleName()), seq);
+    }
+
+    private String pascalToSnake(String input) {
+        StringBuilder output = new StringBuilder();
+        output.append(Character.toLowerCase(input.charAt(0)));
+
+        for (int i = 1; i < input.length(); i++) {
+            if (65 <= input.charAt(i) && input.charAt(i) <= 90) {
+                output.append('_').append(Character.toLowerCase(input.charAt(i)));
+            } else {
+                output.append(input.charAt(i));
+            }
+        }
+
+        return output.toString();
+    }
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/common/mapper/CommonMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/common/mapper/CommonMapper.java
@@ -2,7 +2,11 @@ package error.pirate.backend.common.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 @Mapper
 public interface CommonMapper {
     String nameGenerator(String domainName);
+
+    List<Integer> remainingQuantity(String selectDomainName, String joinDomainName, long seq);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/exception/ErrorCodeType.java
@@ -35,6 +35,7 @@ public enum ErrorCodeType {
     // 출하지시서 관련 오류
     SHIPPING_INSTRUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_INSTRUCTION_ERROR_001", "출하지시서를 찾을 수 없습니다."),
     SHIPPING_INSTRUCTION_STATE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "SHIPPING_INSTRUCTION_ERROR_002", "출하지시서의 상태를 확인해주세요"),
+    SHIPPING_INSTRUCTION_ITEM_NOT_MATCH(HttpStatus.BAD_REQUEST, "SHIPPING_INSTRUCTION_ERROR_003", "출하지시서의 아이템이 주문서와 다릅니다."),
 
     // 출하전표 관련 오류
     SHIPPING_SLIP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_SLIP_ERROR_001", "출하전표를 찾을 수 없습니다."),

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/repository/ShippingInstructionRepository.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/repository/ShippingInstructionRepository.java
@@ -1,10 +1,11 @@
 package error.pirate.backend.shippingInstruction.command.domain.repository;
 
+import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ShippingInstructionRepository extends JpaRepository<ShippingInstruction, Long> {
-    long countByShippingInstructionRegDateBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
+    List<ShippingInstruction> findBySalesOrder(SalesOrder salesOrder);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionItemDomainService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/command/domain/service/ShippingInstructionItemDomainService.java
@@ -1,6 +1,11 @@
 package error.pirate.backend.shippingInstruction.command.domain.service;
 
+import error.pirate.backend.exception.CustomException;
+import error.pirate.backend.exception.ErrorCodeType;
 import error.pirate.backend.item.command.domain.aggregate.entity.Item;
+import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrderItem;
+import error.pirate.backend.salesOrder.command.domain.repository.SalesOrderItemRepository;
+import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionItemRequest;
 import error.pirate.backend.shippingInstruction.command.application.dto.ShippingInstructionRequest;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstructionItem;
@@ -18,6 +23,7 @@ import java.util.List;
 public class ShippingInstructionItemDomainService {
 
     private final ShippingInstructionItemRepository shippingInstructionItemRepository;
+    private final SalesOrderItemRepository salesOrderItemRepository;
 
     /* 도메인 객체를 생성하는 로직 */
     public List<ShippingInstructionItem> createShippingInstructionItemList(
@@ -41,5 +47,25 @@ public class ShippingInstructionItemDomainService {
     /* 출하지시서 번호로 도메인 객체 삭제하는 로직 */
     public void deleteByShippingInstruction(ShippingInstruction newShippingInstruction) {
         shippingInstructionItemRepository.deleteByShippingInstruction(newShippingInstruction);
+    }
+
+    // 주문서 품목과 출하지시서 품목에 대한 검증
+    public void validateItem(long salesOrderSeq, List<ShippingInstructionItemRequest> shippingInstructionItemRequestList) {
+        List<SalesOrderItem> salesOrderItemList =
+                salesOrderItemRepository.findBySalesOrderSalesOrderSeq(salesOrderSeq);
+
+        int matchCount = 0;
+        for (SalesOrderItem salesOrderItem : salesOrderItemList) {
+            for (ShippingInstructionItemRequest shippingInstructionItemRequest : shippingInstructionItemRequestList) {
+                if (salesOrderItem.getItem().getItemSeq().equals(shippingInstructionItemRequest.getItemSeq())) {
+                    matchCount++;
+                }
+            }
+        }
+
+        if (salesOrderItemList.size() < shippingInstructionItemRequestList.size()
+                || matchCount != shippingInstructionItemRequestList.size()) {
+            throw new CustomException(ErrorCodeType.SHIPPING_INSTRUCTION_ITEM_NOT_MATCH);
+        }
     }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/controller/ShippingInstructionQueryController.java
@@ -86,4 +86,15 @@ public class ShippingInstructionQueryController {
                 .headers(headersResponse)
                 .body(excelData);
     }
+
+    @Operation(summary = "출하지시서 등록 시 남아있는 주문서 품목 수량 조회", description = "출하지시서 등록 시 남아있는 주문서 품목 수량 조회")
+    @GetMapping("/quantity/{salesOrderSeq}")
+    public ResponseEntity<List<Integer>> readRemainingQuantity(
+            @PathVariable long salesOrderSeq
+    ) {
+        List<Integer> response
+                = shippingInstructionQueryService.readRemainingQuantity(salesOrderSeq);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionItemCheckDTO.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/dto/ShippingInstructionItemCheckDTO.java
@@ -1,0 +1,9 @@
+package error.pirate.backend.shippingInstruction.query.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ShippingInstructionItemCheckDTO {
+    public Long item;
+    public Integer remainingQuantity;
+}

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/mapper/ShippingInstructionMapper.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/mapper/ShippingInstructionMapper.java
@@ -23,4 +23,6 @@ public interface ShippingInstructionMapper {
 
     List<ShippingInstructionSituationResponse> selectShippingInstructionSituation(
             @Param("request") ShippingInstructionSituationRequest request);
+
+    List<ShippingInstructionItemCheckDTO> sumShippingInstructionItemValue(long salesOrderSeq);
 }

--- a/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
+++ b/SCM/backend/src/main/java/error/pirate/backend/shippingInstruction/query/service/ShippingInstructionQueryService.java
@@ -1,7 +1,10 @@
 package error.pirate.backend.shippingInstruction.query.service;
 
 import error.pirate.backend.common.ExcelDownLoad;
+import error.pirate.backend.common.RemainingQuantity;
 import error.pirate.backend.productionReceiving.query.dto.ProductionReceivingSituationResponse;
+import error.pirate.backend.salesOrder.command.domain.aggregate.entity.SalesOrder;
+import error.pirate.backend.shippingInstruction.command.domain.aggregate.entity.ShippingInstruction;
 import error.pirate.backend.shippingInstruction.query.dto.*;
 import error.pirate.backend.shippingInstruction.query.mapper.ShippingInstructionMapper;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,7 @@ public class ShippingInstructionQueryService {
 
     private final ShippingInstructionMapper shippingInstructionMapper;
     private final ExcelDownLoad excelDownBody;
+    private final RemainingQuantity remainingQuantity;
 
     /* 출하지시서 리스트 조회 */
     @Transactional(readOnly = true)
@@ -131,5 +135,15 @@ public class ShippingInstructionQueryService {
         }
 
         return excelDownBody.excelDownBody(excel, headers, "출하지시서 현황");
+    }
+
+    // 출하지시서 품목 값 확인
+    public List<ShippingInstructionItemCheckDTO> shippingInstructionItemCheck(long salesOrderSeq) {
+        return shippingInstructionMapper.sumShippingInstructionItemValue(salesOrderSeq);
+    }
+
+    // 출하지시서 등록 시 남아있는 주문서 품목 값 리턴
+    public List<Integer> readRemainingQuantity(long salesOrderSeq) {
+        return remainingQuantity.remainingQuantity(SalesOrder.class, ShippingInstruction.class, salesOrderSeq);
     }
 }

--- a/SCM/backend/src/main/resources/mappers/common/CommonMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/common/CommonMapper.xml
@@ -6,9 +6,25 @@
     <!--  이름 생성기  -->
     <select id="nameGenerator" resultType="String">
         SELECT
-            CONCAT(DATE_FORMAT(CURDATE(), '%Y/%m/%d'), ' - ', (COUNT(*) + 1)) AS ${domainName}_name
+        CONCAT(DATE_FORMAT(CURDATE(), '%Y/%m/%d'), ' - ', (COUNT(*) + 1)) AS ${domainName}_name
         FROM tb_${domainName}
         WHERE DATE(${domainName}_reg_date) = CURDATE()
     </select>
 
+    <!--  품목 조회 시 남은 수량 계산 후 조회  -->
+    <select id="remainingQuantity" resultType="Integer">
+        SELECT
+        tb_${selectDomainName}_item.${selectDomainName}_item_quantity - NVL((
+                SELECT
+                    SUM(tb_${joinDomainName}_item.${joinDomainName}_item_quantity)
+                FROM tb_${joinDomainName}
+                JOIN tb_${joinDomainName}_item USING (${joinDomainName}_seq)
+                WHERE tb_${joinDomainName}.${selectDomainName}_seq = tb_${selectDomainName}.${selectDomainName}_seq
+                AND tb_${joinDomainName}_item.item_seq = tb_${selectDomainName}_item.item_seq
+                AND tb_${joinDomainName}.${joinDomainName}_status NOT IN ("DELETE")
+                ), 0) AS remaining_quantity
+        FROM tb_${selectDomainName}
+        JOIN tb_${selectDomainName}_item USING (${selectDomainName}_seq)
+        WHERE tb_${selectDomainName}.${selectDomainName}_seq = #{seq}
+    </select>
 </mapper>

--- a/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
+++ b/SCM/backend/src/main/resources/mappers/shippingInstruction/ShippingInstructionMapper.xml
@@ -131,4 +131,23 @@
             DATE_FORMAT(si.shipping_instruction_scheduled_shipment_date, '%Y/%m'),
             si.shipping_instruction_scheduled_shipment_date WITH ROLLUP;
     </select>
+
+    <!--  출하지시서 품목 값 확인  -->
+    <select id="sumShippingInstructionItemValue"
+            resultType="error.pirate.backend.shippingInstruction.query.dto.ShippingInstructionItemCheckDTO">
+        SELECT
+            soi.item_seq AS item,
+            soi.sales_order_item_quantity - NVL((
+                SELECT
+                    SUM(sii.shipping_instruction_item_quantity)
+                FROM tb_shipping_instruction si
+                JOIN tb_shipping_instruction_item sii ON (si.shipping_instruction_seq = sii.shipping_instruction_seq)
+                WHERE si.sales_order_seq = so.sales_order_seq
+                AND sii.item_seq = item
+                AND si.shipping_instruction_status NOT IN ("DELETE")
+                ), 0) AS remaining_quantity
+        FROM tb_sales_order so
+        JOIN tb_sales_order_item soi ON (so.sales_order_seq = soi.sales_order_seq)
+        WHERE so.sales_order_seq = #{salesOrderSeq}
+    </select>
 </mapper>

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionInputItems.vue
@@ -4,7 +4,7 @@ import trashIcon from '@/assets/trashIcon.svg'
 
 const props = defineProps({
   itemList: {type: Array, required: true},       // 주문서 품목 리스트
-  selectedSalesOrder: {type: Boolean },       // 주문서 선택 여부
+  selectedSalesOrder: {type: Boolean},       // 주문서 선택 여부
 });
 
 const emit = defineEmits(['registerEvent', 'updateItemListEvent']);
@@ -61,11 +61,11 @@ const addShippingInstruction = () => {
 const formatDivision = (divisionString) => {
   if (divisionString === 'FINISHED') {
     return '완제품';
-  }else if(divisionString === 'RAW'){
+  } else if (divisionString === 'RAW') {
     return '구성품';
-  }else if(divisionString === 'PART'){
+  } else if (divisionString === 'PART') {
     return '부재료';
-  }else if(divisionString === 'SUB'){
+  } else if (divisionString === 'SUB') {
     return '원재료';
   }
   return divisionString; // 품목가 다른 경우 그대로 반환
@@ -75,37 +75,43 @@ const formatDivision = (divisionString) => {
 <template>
   <template v-if="props.selectedSalesOrder">
     <div class="col-md-10 d-flex flex-column">
-      <h5 class="px-4">물품 등록</h5>
-      <div style="max-height: 250px; overflow-y: auto;">
-        <div style="max-height: 200px;" v-for="(item, index) in itemList" :key="item.salesOrderItemSeq"
-             class="mx-5 my-3 d-flex flex-row border border-secondary rounded">
-          <b-img class="p-2 col-md-4" src="https://picsum.photos/200/200" fluid alt="Responsive image"></b-img>
-          <div class="p-2 col-md-8">
-            <div class="mb-4 d-flex justify-content-between">
-              <span class="fw-bold">{{ item.itemName }}</span>
-              <trashIcon class="icon" @click="deleteItem(index)"/>
-            </div>
-            <div class="d-flex">
-              <ul class="col-md-4">
-                <li class="mb-3">
-                  · 품목 구분 : {{ formatDivision(item.itemDivision) }}
-                </li>
-                <li class="mb-3 d-flex flex-row">
-                  · 수량 :
-                  <b-form-input class="ms-2 me-2 w-50" type="text" v-model="itemData[index].quantity" size="sm"></b-form-input>
-                  개
-                </li>
-              </ul>
-              <ul class="col-md-8 d-flex flex-column justify-content-between">
-                <li class="d-flex flex-row">
-                  · 비고 :
-                  <b-form-input class="ms-2 w-75" type="text" v-model="itemData[index].note" size="sm"></b-form-input>
-                </li>
-              </ul>
+      <h5 class="px-4">출하지시 물품 등록</h5>
+      <template v-if="itemList.length > 0">
+        <div style="max-height: 250px; overflow-y: auto;">
+          <div style="max-height: 200px;" v-for="(item, index) in itemList" :key="item.salesOrderItemSeq"
+               class="mx-5 my-3 d-flex flex-row border border-secondary rounded">
+            <b-img class="p-2 col-md-4" src="https://picsum.photos/200/200" fluid alt="Responsive image"></b-img>
+            <div class="p-2 col-md-8">
+              <div class="mb-4 d-flex justify-content-between">
+                <span class="fw-bold">{{ item.itemName }}</span>
+                <trashIcon class="icon" @click="deleteItem(index)"/>
+              </div>
+              <div class="d-flex">
+                <ul class="col-md-6">
+                  <li class="mb-3 ">
+                    · 품목 구분 : {{ formatDivision(item.itemDivision) }}
+                  </li>
+                  <li class="mb-3 d-flex flex-row">
+                    · 남은 수량 :
+                    <b-form-input class="ms-2 me-2 w-50" type="text" v-model="itemData[index].quantity"
+                                  size="sm"></b-form-input>
+                    개
+                  </li>
+                </ul>
+                <ul class="col-md-6 d-flex flex-column justify-content-between">
+                  <li class="d-flex flex-row">
+                    · 비고 :
+                    <b-form-input class="ms-2 w-75" type="text" v-model="itemData[index].note" size="sm"></b-form-input>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </template>
+      <template v-else>
+        <b-card-text class="no-list-text">주문서 물품이 존재하지 않습니다.</b-card-text>
+      </template>
       <div class="mx-5 my-3 d-flex justify-content-end">
         <b-button class="button mx-3" variant="light" size="sm" @click="addShippingInstruction">확인</b-button>
       </div>
@@ -126,5 +132,10 @@ li {
 .icon {
   width: 20px;
   height: 20px;
+}
+
+.no-list-text {
+  text-align: center;
+  margin-top: 5%;
 }
 </style>


### PR DESCRIPTION
## 📝 PR 설명
등록 시 불러온 주문서나 출하지시서의 수량 확인 절차 로직, 
문서를 불러왔을 때 남은 수량을 보여주는 로직 공통 코드화 및 프론트에 적용

### 📌 관련 이슈
- **해결할 이슈**: Closes #217

### 변경 사항
- **핵심 변경 내용**: 등록 시 불러온 주문서나 출하지시서의 수량 확인 절차 로직, 
문서를 불러왔을 때 남은 수량을 보여주는 로직 공통 코드화 및 프론트에 적용
- **주요 변경 파일 및 모듈**: 공통코드로 사용할 RemainingQuantity.java 구현
- 쿼리 서비스와 커맨드 서비스 수정

### 🔍 상세 설명
- **구현 내용**: 등록 시 불러온 주문서나 출하지시서의 수량 확인 절차 로직, 
문서를 불러왔을 때 남은 수량을 보여주는 로직 공통 코드화 및 프론트에 적용
- 남은 개수에 해당하는 수량만 처음에 가져와 집니다. 그리고 수량이 0일 경우에는 등록 물품에 나타나지 않습니다.
- 반드시 한 개 이상의 품목을 등록해야 합니다.
- 결재 전이라면 삭제 할 수 있고, 다시 그 주문서로 등록 할 때 남은 물품으로 추가되서 나타납니다.

- **코드 영향 범위**: 공통 코드 필요시 사용

### ✅ 체크리스트
- [ ] 코드가 컴파일/빌드 됨
- [ ] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 📋 테스트 사항
- **테스트 추가 여부**: 새로운 테스트가 추가되었는지, 기존 테스트가 수정되었는지 여부
- **테스트 환경**: vue 화면 테스트

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d0c1581a-7a48-4c1d-9284-5aa3f1616973)
![image](https://github.com/user-attachments/assets/29658d13-4c94-45f7-a525-1fae0ee111d3)
![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/2ed584e0-2b03-4eac-8d4b-4490d601f1ba/7ca9b425-981e-4aa9-8633-09b43ad3751e/image.png)
![image](https://github.com/user-attachments/assets/79abb23e-937c-480a-b372-a86391b52e6a)


### 📄 참고 사항
노션에 공통 코드에 대한 설명과 사용법 하는 이유 작성했습니다.
