### PR TITLE
feat: 인쇄 미리보기 모달 구현

### DIFF
--- a/SCM/frontend/src/components/common/PrintPreview.vue
+++ b/SCM/frontend/src/components/common/PrintPreview.vue
@@ -15,6 +15,7 @@ const itemInfoTableData = ref([
   { name: "그냥볶음밥", quantity: 459831, unitPrice: 10002000, price: 1000200031},
 ]);
 
+// 본인 데이터 직접 불러오기
 const fetchData = async () => {
   try {
     const response = await fetch('https://localhost:8080/printPreview'); // URL 연결
@@ -31,6 +32,12 @@ const fetchData = async () => {
   }
 };
 
+// 빈칸을 계산하는 computed 속성
+const emptyRows = computed(() => {
+  const totalRows = 10; // 최소 10행을 유지
+  const currentDataCount = itemInfoTableData.value.length;
+  return currentDataCount < totalRows ? totalRows - currentDataCount : 0;
+});
 
 const totalQuantity = computed(() => {
   return itemInfoTableData.value.reduce((sum, product) => sum + product.quantity, 0);
@@ -44,77 +51,103 @@ const totalPrice = computed(() => {
   return itemInfoTableData.value.reduce((sum, product) => sum + product.price * product.quantity, 0);
 });
 
-
 const printPage = () => {
+  const printContent = document.getElementById('print-area').innerHTML; // 특정 영역 가져오기
+  const originalContent = document.body.innerHTML; // 현재 페이지 내용 저장
+
+  // 페이지 내용을 특정 영역으로 교체
+  document.body.innerHTML = printContent;
+
+  // 인쇄
   window.print();
+
+  // 원래 내용 복원
+  document.body.innerHTML = originalContent;
+
+  // SPA일 경우 Vue의 리렌더링 강제 호출
+  location.reload(); // 상태를 새로고침하여 업데이트
 }
 
 onMounted(() => {
   fetchData();
 });
-
 </script>
 
 <template>
-  <div>
-    <!-- 인쇄 미리보기 버튼 -->
-    <button @click="printPage">인쇄 미리보기</button>
+  <!-- print Modal bootstrap -->
+  <div class="modal fade" id="PrintModal" tabindex="-1" aria-labelledby="PrintModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-body" id="print-area">
+          <!-- 인쇄 미리보기 버튼 -->
+          <div class="d-flex justify-content-between">
+            <button @click="printPage">인쇄 미리보기</button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
 
-    <div class="container mt-4">
+          <div class="container mt-4">
 
-      <h2 style="text-align: center">{{ tableTitle }}</h2>
-      <br /><br />
+            <h2 class="text-center">{{ tableTitle }}</h2>
+            <br/><br/>
 
-      <table class="table first-table" style="height: 140px">
-        <tbody  v-for="fileInfo in fileInfoTableData">
-          <tr>
-            <td>{{ fileInfo.fileName }}</td>
-            <td class="color-column">{{ fileInfo.fileNameData }}</td>
-            <td>{{ fileInfo.date }}</td>
-            <td class="color-column">{{ fileInfo.dateData }}</td>
-          </tr>
-          <tr>
-            <td>{{ fileInfo.client }}</td>
-            <td class="color-column">{{ fileInfo.clientData }}</td>
-            <td>{{ fileInfo.user }}</td>
-            <td class="color-column">{{ fileInfo.userData }}</td>
-          </tr>
-          <tr>
-            <td>{{ fileInfo.price }}</td>
-            <td class="color-column" colspan="3">{{ fileInfo.priceData.toLocaleString() }}</td>
-          </tr>
-        </tbody>
-      </table>
+            <table class="table first-table" style="height: 140px">
+              <tbody v-for="fileInfo in fileInfoTableData">
+              <tr>
+                <td class="align-content-center">{{ fileInfo.fileName }}</td>
+                <td class="color-column align-content-center">{{ fileInfo.fileNameData }}</td>
+                <td class="align-content-center">{{ fileInfo.date }}</td>
+                <td class="color-column align-content-center">{{ fileInfo.dateData }}</td>
+              </tr>
+              <tr>
+                <td class="align-content-center">{{ fileInfo.client }}</td>
+                <td class="color-column align-content-center">{{ fileInfo.clientData }}</td>
+                <td class="align-content-center">{{ fileInfo.user }}</td>
+                <td class="color-column align-content-center">{{ fileInfo.userData }}</td>
+              </tr>
+              <tr>
+                <td class="align-content-center">{{ fileInfo.price }}</td>
+                <td class="color-column align-content-center" colspan="3">{{ fileInfo.priceData.toLocaleString() }}</td>
+              </tr>
+              </tbody>
+            </table>
 
-      <table class="table table-bordered second-table">
-        <thead>
-          <tr>
-            <th>품목</th>
-            <th>수량</th>
-            <th>단가</th>
-            <th>금액</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="itemInfo in itemInfoTableData">
-            <td>{{ itemInfo.name }}</td>
-            <td>{{ itemInfo.quantity.toLocaleString() }}</td>
-            <td>{{ itemInfo.unitPrice.toLocaleString() }}</td>
-            <td>{{ itemInfo.price.toLocaleString() }}</td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td>합계</td>
-            <td>{{ totalQuantity.toLocaleString() }}</td>
-            <td>{{ totalUnitPrice.toLocaleString() }}</td>
-            <td>{{ totalPrice.toLocaleString() }}</td>
-          </tr>
-        </tfoot>
-      </table>
+            <table class="table table-bordered second-table">
+              <thead>
+              <tr>
+                <th>품목</th>
+                <th>수량</th>
+                <th>단가</th>
+                <th>금액</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr v-for="(itemInfo, index) in itemInfoTableData" :key="'data-' + index">
+                <td>{{ itemInfo.name }}</td>
+                <td>{{ itemInfo.quantity.toLocaleString() }}</td>
+                <td>{{ itemInfo.unitPrice.toLocaleString() }}</td>
+                <td>{{ itemInfo.price.toLocaleString() }}</td>
+              </tr>
+              <tr v-for="index in emptyRows" :key="'empty-' + index">
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+              </tr>
+              </tbody>
+              <tfoot>
+              <tr>
+                <td>합계</td>
+                <td>{{ totalQuantity.toLocaleString() }}</td>
+                <td>{{ totalUnitPrice.toLocaleString() }}</td>
+                <td>{{ totalPrice.toLocaleString() }}</td>
+              </tr>
+              </tfoot>
+            </table>
 
+          </div>
+        </div>
+      </div>
     </div>
-
   </div>
 </template>
 
@@ -131,9 +164,12 @@ onMounted(() => {
 
 /* 인쇄 시 적용되는 스타일 */
 @media print {
+  @page {margin:0 1.3cm}
+
   body {
     font-family: 'Abhaya Libre', serif;
     font-size: 12px;
+    color-adjust: exact;
   }
 
   .content-to-print {

--- a/SCM/frontend/src/components/shippingInstruction/ShippingInstructionList.vue
+++ b/SCM/frontend/src/components/shippingInstruction/ShippingInstructionList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {defineProps, ref, watch} from 'vue';
+import {computed, defineProps, ref, watch} from 'vue';
 import searchIcon from "@/assets/searchIcon.svg";
 import trashIcon from "@/assets/trashIcon.svg";
 import editIcon from "@/assets/editIcon.svg";
@@ -95,22 +95,53 @@ function numberThree(number) {
   return `${number.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",")}`;
 }
 
-// 인쇄 함수
-const printItem = (index) => {
-  const printContent = document.getElementById(`print-area-${index}`).innerHTML;
-  const originalContent = document.body.innerHTML;
+// 모달에 데이터 전달을 위한 함수
+const printModalData = ref({});
+const extendPrintModalData = ref({});
+const itemPrint = (shippingInstruction) => {
+  printModalData.value = shippingInstruction;
+  extendPrintModalData.value = props.expandShippingInstruction[shippingInstruction.shippingInstructionSeq];
+  console.log(printModalData.value);
+}
 
-  // 선택된 영역만 표시
+// 빈칸을 계산하는 computed 속성
+const emptyRows = computed(() => {
+  const totalRows = 10; // 최소 10행을 유지
+  const currentDataCount = props.expandItemList[printModalData.value.shippingInstructionSeq];
+  // 배열, 객체 여부 확인
+  if (Array.isArray(currentDataCount)) {
+    return currentDataCount.length; // 배열이면 길이를 반환
+  } else if (currentDataCount && typeof currentDataCount === 'object') {
+    return Object.keys(currentDataCount).length; // 객체면 키 개수 반환
+  }
+  return currentDataCount < totalRows ? totalRows - currentDataCount : 0;
+});
+
+// 전체 수량 구하는 computed 속성
+const totalQuantity = computed(() => {
+  const data = props.expandItemList[printModalData.value.shippingInstructionSeq];
+  // 객체 라면
+  if (data && typeof data === 'object') {
+    return Object.values(data).reduce((sum, product) => sum + (product.shippingInstructionItemQuantity || 0), 0);
+  }
+});
+
+const printPage = () => {
+  const printContent = document.getElementById('print-area').innerHTML; // 특정 영역 가져오기
+  const originalContent = document.body.innerHTML; // 현재 페이지 내용 저장
+
+  // 페이지 내용을 특정 영역으로 교체
   document.body.innerHTML = printContent;
 
+  // 인쇄
   window.print();
 
   // 원래 내용 복원
   document.body.innerHTML = originalContent;
 
-  // Vue 리렌더링 방지
-  location.reload();
-};
+  // SPA일 경우 Vue의 리렌더링 강제 호출
+  location.reload(); // 상태를 새로고침하여 업데이트
+}
 </script>
 
 <template>
@@ -186,18 +217,26 @@ const printItem = (index) => {
                   <div v-if="expandShippingInstruction[shippingInstruction.shippingInstructionSeq]"
                        class="col-md-11 mt-3">
                     <b>총수량 : </b>
-                    {{ expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionTotalQuantity }} 개<br>
+                    {{
+                      expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionTotalQuantity
+                    }} 개<br>
                     <b>출하 주소 : </b>
-                    {{ findStatusValue(shippingAddressList,
-                      expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingAddress) }}
-                    {{  }}<br>
+                    {{
+                      findStatusValue(shippingAddressList,
+                          expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingAddress)
+                    }}<br>
                     <b>담당자 : </b>
                     {{ expandShippingInstruction[shippingInstruction.shippingInstructionSeq].userName }}<br>
                     <b>출하예정일시 : </b>
-                    {{ dayjs(expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionScheduledShipmentDate).format('YYYY/MM/DD HH:mm:ss') }}<br>
-                    <div v-if="expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionNote">
+                    {{
+                      dayjs(expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionScheduledShipmentDate).format('YYYY/MM/DD HH:mm:ss')
+                    }}<br>
+                    <div
+                        v-if="expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionNote">
                       <b>출하지시서 비고 :</b>
-                      {{ expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionNote }}<br>
+                      {{
+                        expandShippingInstruction[shippingInstruction.shippingInstructionSeq].shippingInstructionNote
+                      }}<br>
                     </div>
                     <div v-else>
                       <b>출하지시서 비고 :</b>없음<br>
@@ -223,9 +262,10 @@ const printItem = (index) => {
                     </div>
                     <div class="d-flex justify-content-end align-items-center">
                       <b-button v-if="shippingInstruction.shippingInstructionStatus === 'AFTER'" variant="light"
-                                class="me-3 button" @click="shippingSlipRegister(shippingInstruction.shippingInstructionSeq)">출하전표 등록
+                                class="me-3 button" size="sm"
+                                @click="shippingSlipRegister(shippingInstruction.shippingInstructionSeq)">출하전표 등록
                       </b-button>
-                      <printIcon class="me-3 icon" @click.stop="printItem(index)"/>
+                      <printIcon class="me-3 icon" data-bs-toggle="modal" data-bs-target="#PrintModal" @click.stop="itemPrint(shippingInstruction)"/>
                       <editIcon v-if="shippingInstruction.shippingInstructionStatus === 'BEFORE'" class="me-3 icon"
                                 @click.stop="itemEdit(shippingInstruction.shippingInstructionSeq)"/>
                       <trashIcon v-if="shippingInstruction.shippingInstructionStatus === 'BEFORE'" class="icon"
@@ -247,6 +287,76 @@ const printItem = (index) => {
         <template v-else>
           <b-card-text class="no-list-text">해당 검색조건에 부합한 출하지시서가 존재하지 않습니다.</b-card-text>
         </template>
+      </div>
+    </div>
+  </div>
+  <!-- print Modal bootstrap -->
+  <div class="modal fade" id="PrintModal" tabindex="-1" aria-labelledby="PrintModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-body" id="print-area">
+          <!-- 인쇄 미리보기 버튼 -->
+          <div class="d-flex justify-content-between">
+            <button class="button" @click="printPage">인쇄 미리보기</button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+
+          <div class="container mt-4">
+
+            <h2 class="text-center">출하지시서</h2>
+            <br/><br/>
+
+            <table class="table first-table" style="height: 140px">
+              <tbody>
+              <tr>
+                <td class="align-content-center">출하지시서명</td>
+                <td class="color-column align-content-center">{{ printModalData.shippingInstructionName }}</td>
+              </tr>
+              <tr>
+                <td class="align-content-center">출하예정일</td>
+                <td class="color-column align-content-center">{{ dayjs(printModalData.shippingInstructionScheduledShipmentDate).format('YYYY/MM/DD') }}</td>
+              </tr>
+              <tr>
+                <td class="align-content-center">거래처</td>
+                <td class="color-column align-content-center">{{ printModalData.clientName }}</td>
+                <td class="align-content-center">담당자</td>
+                <td class="color-column align-content-center">{{ extendPrintModalData.userName }}</td>
+              </tr>
+              <tr>
+                <td class="align-content-center">출하주소</td>
+                <td class="color-column align-content-center" colspan="3">
+                  {{ findStatusValue(shippingAddressList, extendPrintModalData.shippingAddress) }}</td>
+              </tr>
+              </tbody>
+            </table>
+
+            <table class="table table-bordered second-table">
+              <thead>
+              <tr>
+                <th>품목</th>
+                <th>수량</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr v-for="(itemInfo, index) in expandItemList[printModalData.shippingInstructionSeq]" :key="'data-' + index">
+                <td>{{ itemInfo.itemName }}</td>
+                <td>{{ numberThree(itemInfo.shippingInstructionItemQuantity) }}</td>
+              </tr>
+              <tr v-for="index in emptyRows" :key="'empty-' + index">
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+              </tr>
+              </tbody>
+              <tfoot>
+              <tr>
+                <td>합계</td>
+                <td>{{ totalQuantity }}</td>
+              </tr>
+              </tfoot>
+            </table>
+
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -299,7 +409,7 @@ div {
   word-break: keep-all;
 }
 
-.pagenation {
+.pagination {
   justify-items: center;
   margin-top: 20px;
 }
@@ -324,5 +434,34 @@ div {
   object-fit: cover;
 }
 
+.table {
+  text-align: center;
+  border-collapse: collapse;
+}
 
+.color-column {
+  background-color: #f5f5f5;
+  border-radius: 15px;
+}
+
+/* 인쇄 시 적용되는 스타일 */
+@media print {
+  @page {margin:0 1.3cm}
+
+  body {
+    font-family: 'Abhaya Libre', serif;
+    font-size: 12px;
+    color-adjust: exact;
+  }
+
+  .content-to-print {
+    padding: 0;
+    border: none;
+  }
+
+  /* 인쇄 미리보기에서 버튼 숨기기 - 꼭 있어야함!!!! */
+  button {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
## 📝 PR 설명
인쇄 미리보기 모달 구현

### 📌 관련 이슈
- **해결할 이슈**: Closes #262 

### 변경 사항
- **핵심 변경 내용**: 인쇄 미리보기 모달 구현
- **주요 변경 파일 및 모듈**: PrintPreview.vue ShippingInstructionList.vue

### 🔍 상세 설명
- **구현 내용**: 기존에 있던 PrintPreview 를 모달 형태로 변경하였습니다.
- 값을 대입해서 넣을 실 때 각 데이터에 맞게 넣으면 잘 나타납니다.
- 어떤 식으로 나오는 지 궁금하시면 ShippingInstructionList 컴포넌트의 293번째 줄부터 362번째 줄까지와 98번째 줄부터 144번째 줄 까지입니다.
- 저는 데이터를 받아올 때 배열이 아닌 객체로 props로 받아오기 때문에 조금 computed 속성에서 로직 변경이 있습니다.
- 참고하시고 물어보실 거 질문해 주세요. 
- **코드 영향 범위**: PrintPreview 가 변경됨

### ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됨
- [x] 테스트가 통과함 (단위 테스트 및 통합 테스트 포함)
- [ ] 문서가 업데이트됨 (필요시)

### 🖥️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b035ea7b-216f-4dc8-8f7c-45f48f499d21)
![image](https://github.com/user-attachments/assets/dc48887c-b0e4-4a0f-a78c-dd50d8b97e02)


### 📄 참고 사항
ShippingInstructionList 컴포넌트의 293번째 줄부터 362번째 줄까지와 98번째 줄부터 144번째 줄 까지입니다.
PrintPreview 의 데이터를 제 데이터에 맞게 변경하였습니다.
